### PR TITLE
Milestone 2: Linux CLI with side-by-side Bash support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,8 @@ CACHEDIR.TAG
 # Go
 coverage.out
 *.test
+/ow
+/ow.exe
 
 # Backup files
 *~

--- a/cmd/ow/config_cmd.go
+++ b/cmd/ow/config_cmd.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func runConfigShow(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Resolve(nil)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshalling config: %w", err)
+	}
+
+	fmt.Print(string(out))
+	return nil
+}

--- a/cmd/ow/containers_cmd.go
+++ b/cmd/ow/containers_cmd.go
@@ -1,0 +1,193 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/docker"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+	"github.com/spf13/cobra"
+)
+
+// Volume mount paths inside containers. These are hardcoded constants
+// that must match the upstream container expectations. Changing them
+// breaks data persistence.
+const (
+	ollamaVolPath    = "/root/.ollama"
+	openWebUIVolPath = "/app/backend/data"
+)
+
+var containersCmd = &cobra.Command{
+	Use:   "containers",
+	Short: "Manage Docker containers",
+}
+
+var containersUpCmd = &cobra.Command{
+	Use:   "up",
+	Short: "Pull images and start Ollama and OpenWebUI containers",
+	RunE:  runContainersUp,
+}
+
+var containersDownCmd = &cobra.Command{
+	Use:   "down",
+	Short: "Stop and remove Ollama and OpenWebUI containers",
+	RunE:  runContainersDown,
+}
+
+var containersStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show running state of Ollama and OpenWebUI containers",
+	RunE:  runContainersStatus,
+}
+
+func init() {
+	rootCmd.AddCommand(containersCmd)
+	containersCmd.AddCommand(containersUpCmd)
+	containersCmd.AddCommand(containersDownCmd)
+	containersCmd.AddCommand(containersStatusCmd)
+}
+
+// ollamaContainerConfig builds the Docker container config for Ollama.
+func ollamaContainerConfig(cfg config.Config) docker.ContainerConfig {
+	return docker.ContainerConfig{
+		Name:    cfg.Ollama.Container,
+		Image:   cfg.Ollama.Image,
+		Tag:     cfg.Ollama.Tag,
+		Volume:  cfg.Ollama.Volume,
+		VolPath: ollamaVolPath,
+		Env: map[string]string{
+			"OLLAMA_HOST": cfg.Ollama.Host,
+		},
+		GPUs:    "all",
+		Network: "host",
+		Restart: "always",
+	}
+}
+
+// openWebUIContainerConfig builds the Docker container config for OpenWebUI.
+func openWebUIContainerConfig(cfg config.Config) docker.ContainerConfig {
+	ollamaURL := fmt.Sprintf("http://%s:%d", cfg.Ollama.Host, cfg.Ollama.Port)
+	return docker.ContainerConfig{
+		Name:    cfg.OpenWebUI.Container,
+		Image:   cfg.OpenWebUI.Image,
+		Tag:     cfg.OpenWebUI.Tag,
+		Volume:  cfg.OpenWebUI.Volume,
+		VolPath: openWebUIVolPath,
+		Env: map[string]string{
+			"OLLAMA_BASE_URL": ollamaURL,
+			"PORT":            fmt.Sprintf("%d", cfg.OpenWebUI.Port),
+		},
+		GPUs:    "all",
+		Network: "host",
+		Restart: "always",
+	}
+}
+
+func newDockerClient() (*docker.Client, *logging.Logger, error) {
+	logger, err := logging.NewLogger("", logging.Info)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating logger: %w", err)
+	}
+	runner := &exec.RealRunner{Logger: logger}
+	return docker.NewClient(runner, logger), logger, nil
+}
+
+func runContainersUp(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Resolve(nil)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	client, logger, err := newDockerClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	ollamaCfg := ollamaContainerConfig(cfg)
+	openWebUICfg := openWebUIContainerConfig(cfg)
+
+	// Pull images.
+	if err := client.PullImage(ctx, ollamaCfg.Image, ollamaCfg.Tag); err != nil {
+		return fmt.Errorf("pulling ollama image: %w", err)
+	}
+	if err := client.PullImage(ctx, openWebUICfg.Image, openWebUICfg.Tag); err != nil {
+		return fmt.Errorf("pulling openwebui image: %w", err)
+	}
+
+	// Start Ollama, wait for container, then health check.
+	if err := client.EnsureRunning(ctx, ollamaCfg); err != nil {
+		return fmt.Errorf("starting ollama: %w", err)
+	}
+	logger.Info("waiting for Ollama health check on port %d", cfg.Ollama.Port)
+	if err := client.WaitForHTTP(ctx, cfg.Ollama.Host, cfg.Ollama.Port, "/", exec.DefaultRetryOpts()); err != nil {
+		return fmt.Errorf("ollama health check: %w", err)
+	}
+
+	// Start OpenWebUI, wait for container, then health check.
+	if err := client.EnsureRunning(ctx, openWebUICfg); err != nil {
+		return fmt.Errorf("starting openwebui: %w", err)
+	}
+	logger.Info("waiting for OpenWebUI health check on port %d", cfg.OpenWebUI.Port)
+	if err := client.WaitForHTTP(ctx, cfg.OpenWebUI.Host, cfg.OpenWebUI.Port, "/", exec.DefaultRetryOpts()); err != nil {
+		return fmt.Errorf("openwebui health check: %w", err)
+	}
+
+	logger.Info("all containers running")
+	return nil
+}
+
+func runContainersDown(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Resolve(nil)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	client, _, err := newDockerClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+
+	// Stop OpenWebUI first, then Ollama.
+	if err := client.StopAndRemove(ctx, cfg.OpenWebUI.Container); err != nil {
+		return fmt.Errorf("stopping openwebui: %w", err)
+	}
+	if err := client.StopAndRemove(ctx, cfg.Ollama.Container); err != nil {
+		return fmt.Errorf("stopping ollama: %w", err)
+	}
+
+	return nil
+}
+
+func runContainersStatus(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Resolve(nil)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	client, _, err := newDockerClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+
+	for _, name := range []string{cfg.Ollama.Container, cfg.OpenWebUI.Container} {
+		running, err := client.ContainerIsRunning(ctx, name)
+		if err != nil {
+			return fmt.Errorf("checking %s: %w", name, err)
+		}
+		status := "stopped"
+		if running {
+			status = "running"
+		}
+		fmt.Printf("%-20s %s\n", name, status)
+	}
+
+	return nil
+}

--- a/cmd/ow/containers_cmd_test.go
+++ b/cmd/ow/containers_cmd_test.go
@@ -1,0 +1,126 @@
+//go:build linux
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+)
+
+// TestOllamaContainerConfigMatchesBash verifies that the Go container config
+// produces docker run arguments identical to the Bash scripts.
+//
+// Bash (repo_lib.sh lines 572-579):
+//
+//	docker run -d \
+//	    --gpus all \
+//	    --network=host \
+//	    --volume ollama:/root/.ollama \
+//	    --env OLLAMA_HOST=localhost \
+//	    --restart always \
+//	    --name ollama \
+//	    ollama/ollama:latest
+func TestOllamaContainerConfigMatchesBash(t *testing.T) {
+	cfg := config.Defaults()
+	cc := ollamaContainerConfig(cfg)
+
+	got := cc.RunArgs()
+	want := []string{
+		"run", "-d",
+		"--name", "ollama",
+		"--gpus", "all",
+		"--network", "host",
+		"--restart", "always",
+		"--volume", "ollama:/root/.ollama",
+		"--env", "OLLAMA_HOST=localhost",
+		"ollama/ollama:latest",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ollama RunArgs() =\n  %v\nwant\n  %v", got, want)
+	}
+}
+
+// TestOpenWebUIContainerConfigMatchesBash verifies that the Go container config
+// produces docker run arguments identical to the Bash scripts.
+//
+// Bash (repo_lib.sh lines 647-655):
+//
+//	docker run -d \
+//	    --gpus all \
+//	    --network=host \
+//	    --volume open-webui:/app/backend/data \
+//	    --env OLLAMA_BASE_URL=http://localhost:11434 \
+//	    --env PORT=3000 \
+//	    --name open-webui \
+//	    --restart always \
+//	    ghcr.io/open-webui/open-webui:latest
+func TestOpenWebUIContainerConfigMatchesBash(t *testing.T) {
+	cfg := config.Defaults()
+	cc := openWebUIContainerConfig(cfg)
+
+	got := cc.RunArgs()
+	want := []string{
+		"run", "-d",
+		"--name", "open-webui",
+		"--gpus", "all",
+		"--network", "host",
+		"--restart", "always",
+		"--volume", "open-webui:/app/backend/data",
+		"--env", "OLLAMA_BASE_URL=http://localhost:11434",
+		"--env", "PORT=3000",
+		"ghcr.io/open-webui/open-webui:latest",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("openwebui RunArgs() =\n  %v\nwant\n  %v", got, want)
+	}
+}
+
+func TestOllamaContainerConfigCustomValues(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Ollama.Container = "my-ollama"
+	cfg.Ollama.Tag = "0.3.0"
+	cfg.Ollama.Volume = "my-vol"
+	cfg.Ollama.Host = "0.0.0.0"
+
+	cc := ollamaContainerConfig(cfg)
+
+	if cc.Name != "my-ollama" {
+		t.Errorf("Name = %q, want %q", cc.Name, "my-ollama")
+	}
+	if cc.Tag != "0.3.0" {
+		t.Errorf("Tag = %q, want %q", cc.Tag, "0.3.0")
+	}
+	if cc.Volume != "my-vol" {
+		t.Errorf("Volume = %q, want %q", cc.Volume, "my-vol")
+	}
+	if cc.Env["OLLAMA_HOST"] != "0.0.0.0" {
+		t.Errorf("Env[OLLAMA_HOST] = %q, want %q", cc.Env["OLLAMA_HOST"], "0.0.0.0")
+	}
+	if cc.VolPath != ollamaVolPath {
+		t.Errorf("VolPath = %q, want %q", cc.VolPath, ollamaVolPath)
+	}
+}
+
+func TestOpenWebUIContainerConfigCustomValues(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.OpenWebUI.Port = 8080
+	cfg.Ollama.Port = 11435
+	cfg.Ollama.Host = "192.168.1.10"
+
+	cc := openWebUIContainerConfig(cfg)
+
+	if cc.Env["PORT"] != "8080" {
+		t.Errorf("Env[PORT] = %q, want %q", cc.Env["PORT"], "8080")
+	}
+	if cc.Env["OLLAMA_BASE_URL"] != "http://192.168.1.10:11435" {
+		t.Errorf("Env[OLLAMA_BASE_URL] = %q, want %q",
+			cc.Env["OLLAMA_BASE_URL"], "http://192.168.1.10:11435")
+	}
+	if cc.VolPath != openWebUIVolPath {
+		t.Errorf("VolPath = %q, want %q", cc.VolPath, openWebUIVolPath)
+	}
+}

--- a/cmd/ow/diagnose_cmd.go
+++ b/cmd/ow/diagnose_cmd.go
@@ -1,0 +1,123 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/user"
+	"strings"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+	"github.com/spf13/cobra"
+)
+
+var diagnoseCmd = &cobra.Command{
+	Use:   "diagnose",
+	Short: "Run diagnostic checks on the system, Docker, and containers",
+	RunE:  runDiagnose,
+}
+
+func init() {
+	rootCmd.AddCommand(diagnoseCmd)
+}
+
+// diagSection prints a section header and runs a command, printing its output.
+// Errors are printed but do not stop the diagnostic flow.
+func diagSection(ctx context.Context, runner exec.Runner, header string, bin string, args ...string) {
+	fmt.Printf("=== %s ===\n", header)
+	out, err := runner.Run(ctx, bin, args...)
+	if err != nil {
+		fmt.Printf("  (error: %v)\n", err)
+	} else {
+		fmt.Println(strings.TrimRight(out, "\n"))
+	}
+	fmt.Println()
+}
+
+func runDiagnose(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Resolve(nil)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	logger, err := logging.NewLogger("", logging.Info)
+	if err != nil {
+		return fmt.Errorf("creating logger: %w", err)
+	}
+
+	runner := &exec.RealRunner{Logger: logger}
+	ctx := cmd.Context()
+
+	// Basic system info.
+	fmt.Println("=== Basic System Info ===")
+	if u, err := user.Current(); err == nil {
+		fmt.Printf("User: %s\n", u.Username)
+	}
+	out, err := runner.Run(ctx, "cat", "/etc/os-release")
+	if err == nil {
+		fmt.Println(strings.TrimRight(out, "\n"))
+	}
+	fmt.Println()
+
+	// Network interfaces.
+	diagSection(ctx, runner, "Network Interfaces & IPs", "ip", "addr", "show")
+
+	// Listening ports.
+	diagSection(ctx, runner, "Listening Ports (TCP)", "lsof", "-i", "-P", "-n")
+
+	// NVIDIA status.
+	diagSection(ctx, runner, "NVIDIA GPU Status", "nvidia-smi")
+
+	// Docker diagnostics.
+	diagSection(ctx, runner, "Docker Version", "docker", "--version")
+	diagSection(ctx, runner, "Docker Containers", "docker", "ps")
+	diagSection(ctx, runner, "Docker Images", "docker", "images")
+
+	// Test port connectivity.
+	fmt.Printf("=== Test Ollama Port (%d) ===\n", cfg.Ollama.Port)
+	url := fmt.Sprintf("http://%s:%d", cfg.Ollama.Host, cfg.Ollama.Port)
+	if _, err := runner.Run(ctx, "curl", "-sf", url); err != nil {
+		fmt.Printf("  HTTP check failed: %v\n", err)
+	} else {
+		fmt.Printf("  HTTP check succeeded on port %d\n", cfg.Ollama.Port)
+	}
+	fmt.Println()
+
+	fmt.Printf("=== Test OpenWebUI Port (%d) ===\n", cfg.OpenWebUI.Port)
+	url = fmt.Sprintf("http://%s:%d", cfg.OpenWebUI.Host, cfg.OpenWebUI.Port)
+	if _, err := runner.Run(ctx, "curl", "-sf", url); err != nil {
+		fmt.Printf("  HTTP check failed: %v\n", err)
+	} else {
+		fmt.Printf("  HTTP check succeeded on port %d\n", cfg.OpenWebUI.Port)
+	}
+	fmt.Println()
+
+	// Container logs (filtered for errors/warnings).
+	for _, name := range []string{cfg.Ollama.Container, cfg.OpenWebUI.Container} {
+		fmt.Printf("=== %s Container Logs ===\n", name)
+		out, err := runner.Run(ctx, "docker", "logs", "--tail", "50", name)
+		if err != nil {
+			fmt.Printf("  (error: %v)\n", err)
+		} else {
+			for _, line := range strings.Split(out, "\n") {
+				lower := strings.ToLower(line)
+				if strings.Contains(lower, "error") ||
+					strings.Contains(lower, "warn") ||
+					strings.Contains(lower, "listen") {
+					fmt.Println(line)
+				}
+			}
+		}
+		fmt.Println()
+	}
+
+	// Routing and connectivity.
+	diagSection(ctx, runner, "Default Routes", "ip", "route", "show", "default")
+	diagSection(ctx, runner, "External Connectivity", "ping", "-c", "4", "google.com")
+
+	fmt.Println("=== END DIAGNOSTICS ===")
+	return nil
+}

--- a/cmd/ow/diagnose_cmd_test.go
+++ b/cmd/ow/diagnose_cmd_test.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+package main
+
+import (
+	"testing"
+)
+
+func TestDiagnoseCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "diagnose" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("diagnose command not registered on rootCmd")
+	}
+}

--- a/cmd/ow/integration_test.go
+++ b/cmd/ow/integration_test.go
@@ -1,0 +1,116 @@
+//go:build linux && integration
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// TestConfigShowRoundTrip builds the binary, runs `ow config show`, and
+// verifies the YAML output unmarshals back to a config matching Defaults().
+func TestConfigShowRoundTrip(t *testing.T) {
+	binary := buildOW(t)
+
+	out, err := exec.Command(binary, "config", "show").CombinedOutput()
+	if err != nil {
+		t.Fatalf("ow config show failed: %v\n%s", err, out)
+	}
+
+	var got config.Config
+	if err := yaml.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal config show output: %v", err)
+	}
+
+	want := config.Defaults()
+
+	if got.Ollama.Port != want.Ollama.Port {
+		t.Errorf("ollama.port: got %d, want %d", got.Ollama.Port, want.Ollama.Port)
+	}
+	if got.Ollama.Host != want.Ollama.Host {
+		t.Errorf("ollama.host: got %q, want %q", got.Ollama.Host, want.Ollama.Host)
+	}
+	if got.Ollama.Container != want.Ollama.Container {
+		t.Errorf("ollama.container: got %q, want %q", got.Ollama.Container, want.Ollama.Container)
+	}
+	if got.OpenWebUI.Port != want.OpenWebUI.Port {
+		t.Errorf("openwebui.port: got %d, want %d", got.OpenWebUI.Port, want.OpenWebUI.Port)
+	}
+	if got.OpenWebUI.Container != want.OpenWebUI.Container {
+		t.Errorf("openwebui.container: got %q, want %q", got.OpenWebUI.Container, want.OpenWebUI.Container)
+	}
+	if len(got.Ollama.Models) != len(want.Ollama.Models) {
+		t.Fatalf("models count: got %d, want %d", len(got.Ollama.Models), len(want.Ollama.Models))
+	}
+	for i := range want.Ollama.Models {
+		if got.Ollama.Models[i] != want.Ollama.Models[i] {
+			t.Errorf("models[%d]: got %q, want %q", i, got.Ollama.Models[i], want.Ollama.Models[i])
+		}
+	}
+}
+
+// TestVersionOutput verifies that `ow version` runs and includes the OS/arch.
+func TestVersionOutput(t *testing.T) {
+	binary := buildOW(t)
+
+	out, err := exec.Command(binary, "version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("ow version failed: %v\n%s", err, out)
+	}
+
+	output := string(out)
+	if !strings.Contains(output, "linux") {
+		t.Errorf("version output missing 'linux': %s", output)
+	}
+}
+
+// TestSubcommandTree verifies all expected subcommands exist.
+func TestSubcommandTree(t *testing.T) {
+	binary := buildOW(t)
+
+	tests := []struct {
+		args []string
+		want string
+	}{
+		{[]string{"help"}, "setup"},
+		{[]string{"help"}, "containers"},
+		{[]string{"help"}, "ollama"},
+		{[]string{"help"}, "diagnose"},
+		{[]string{"help"}, "config"},
+		{[]string{"help"}, "version"},
+		{[]string{"containers", "help"}, "up"},
+		{[]string{"containers", "help"}, "down"},
+		{[]string{"containers", "help"}, "status"},
+		{[]string{"ollama", "help"}, "pull"},
+		{[]string{"ollama", "help"}, "models"},
+		{[]string{"ollama", "help"}, "run"},
+	}
+
+	for _, tt := range tests {
+		out, err := exec.Command(binary, tt.args...).CombinedOutput()
+		if err != nil {
+			t.Errorf("ow %s failed: %v", strings.Join(tt.args, " "), err)
+			continue
+		}
+		if !strings.Contains(string(out), tt.want) {
+			t.Errorf("ow %s output missing %q:\n%s",
+				strings.Join(tt.args, " "), tt.want, out)
+		}
+	}
+}
+
+// buildOW compiles the ow binary for the current platform and returns
+// the path. It uses t.TempDir() for the output.
+func buildOW(t *testing.T) string {
+	t.Helper()
+	binary := t.TempDir() + "/ow"
+	cmd := exec.Command("go", "build", "-o", binary, "./cmd/ow/")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return binary
+}

--- a/cmd/ow/main.go
+++ b/cmd/ow/main.go
@@ -1,16 +1,11 @@
 package main
 
 import (
-	"fmt"
-	"runtime"
-)
-
-var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
+	"os"
 )
 
 func main() {
-	fmt.Printf("ow %s %s %s %s/%s\n", version, commit, date, runtime.GOOS, runtime.GOARCH)
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }

--- a/cmd/ow/ollama_cmd.go
+++ b/cmd/ow/ollama_cmd.go
@@ -1,0 +1,112 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"syscall"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/ollama"
+	"github.com/spf13/cobra"
+)
+
+var ollamaCmd = &cobra.Command{
+	Use:   "ollama",
+	Short: "Manage Ollama models",
+}
+
+var ollamaPullCmd = &cobra.Command{
+	Use:   "pull",
+	Short: "Pull configured models (or specify model names as arguments)",
+	RunE:  runOllamaPull,
+}
+
+var ollamaModelsCmd = &cobra.Command{
+	Use:   "models",
+	Short: "List installed models",
+	RunE:  runOllamaModels,
+}
+
+var ollamaRunCmd = &cobra.Command{
+	Use:   "run [model]",
+	Short: "Run a model interactively",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runOllamaRun,
+}
+
+func init() {
+	rootCmd.AddCommand(ollamaCmd)
+	ollamaCmd.AddCommand(ollamaPullCmd)
+	ollamaCmd.AddCommand(ollamaModelsCmd)
+	ollamaCmd.AddCommand(ollamaRunCmd)
+}
+
+func newOllamaManager() (*ollama.Manager, error) {
+	logger, err := logging.NewLogger("", logging.Info)
+	if err != nil {
+		return nil, fmt.Errorf("creating logger: %w", err)
+	}
+	runner := &exec.RealRunner{Logger: logger}
+	return ollama.NewManager(runner, logger), nil
+}
+
+func runOllamaPull(cmd *cobra.Command, args []string) error {
+	mgr, err := newOllamaManager()
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+
+	// If models specified as arguments, pull those. Otherwise use config.
+	models := args
+	if len(models) == 0 {
+		cfg, err := config.Resolve(nil)
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+		models = cfg.Ollama.Models
+	}
+
+	return mgr.PullModels(ctx, models)
+}
+
+func runOllamaModels(cmd *cobra.Command, args []string) error {
+	mgr, err := newOllamaManager()
+	if err != nil {
+		return err
+	}
+
+	models, err := mgr.ListModels(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	if len(models) == 0 {
+		fmt.Println("No models installed.")
+		return nil
+	}
+
+	for _, m := range models {
+		fmt.Println(m)
+	}
+	return nil
+}
+
+func runOllamaRun(cmd *cobra.Command, args []string) error {
+	model := args[0]
+
+	// Use syscall.Exec to replace the process with ollama run,
+	// giving the user a direct interactive terminal session.
+	binary, err := osexec.LookPath("ollama")
+	if err != nil {
+		return fmt.Errorf("ollama not found in PATH: %w", err)
+	}
+
+	return syscall.Exec(binary, []string{"ollama", "run", model}, os.Environ())
+}

--- a/cmd/ow/ollama_cmd.go
+++ b/cmd/ow/ollama_cmd.go
@@ -108,5 +108,5 @@ func runOllamaRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("ollama not found in PATH: %w", err)
 	}
 
-	return syscall.Exec(binary, []string{"ollama", "run", model}, os.Environ())
+	return syscall.Exec(binary, []string{"ollama", "run", model}, os.Environ()) //nolint:gosec // G204: binary is from LookPath("ollama"), not user input
 }

--- a/cmd/ow/ollama_cmd_test.go
+++ b/cmd/ow/ollama_cmd_test.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package main
+
+import (
+	"testing"
+)
+
+func TestOllamaRunRequiresExactlyOneArg(t *testing.T) {
+	// The cobra command has Args: cobra.ExactArgs(1).
+	// Verify the command is configured correctly.
+	if ollamaRunCmd.Args == nil {
+		t.Fatal("ollamaRunCmd.Args should not be nil")
+	}
+
+	// Zero args should fail.
+	if err := ollamaRunCmd.Args(ollamaRunCmd, []string{}); err == nil {
+		t.Error("expected error with zero args")
+	}
+
+	// One arg should pass.
+	if err := ollamaRunCmd.Args(ollamaRunCmd, []string{"llama3.2:1b"}); err != nil {
+		t.Errorf("expected no error with one arg, got: %v", err)
+	}
+
+	// Two args should fail.
+	if err := ollamaRunCmd.Args(ollamaRunCmd, []string{"a", "b"}); err == nil {
+		t.Error("expected error with two args")
+	}
+}
+
+func TestOllamaPullAcceptsVariadicArgs(t *testing.T) {
+	// ollamaPullCmd has no Args constraint, so any number should work.
+	// With zero args it falls back to config models.
+	// This test just verifies the command exists and is wired up.
+	if ollamaPullCmd.Use != "pull" {
+		t.Errorf("Use = %q, want %q", ollamaPullCmd.Use, "pull")
+	}
+}
+
+func TestOllamaModelsCommandExists(t *testing.T) {
+	if ollamaModelsCmd.Use != "models" {
+		t.Errorf("Use = %q, want %q", ollamaModelsCmd.Use, "models")
+	}
+}
+
+func TestOllamaSubcommandRegistration(t *testing.T) {
+	subs := ollamaCmd.Commands()
+	names := make(map[string]bool, len(subs))
+	for _, s := range subs {
+		names[s.Use] = true
+	}
+
+	for _, want := range []string{"pull", "models", "run [model]"} {
+		if !names[want] {
+			t.Errorf("missing subcommand %q in ollama command", want)
+		}
+	}
+}

--- a/cmd/ow/root.go
+++ b/cmd/ow/root.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "ow",
+	Short: "OpenWebUI + Ollama setup tool",
+	Long:  "Automates installation and management of OpenWebUI and Ollama with GPU support.",
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version and build info",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("ow %s %s %s %s/%s\n", version, commit, date, runtime.GOOS, runtime.GOARCH)
+	},
+}
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Configuration management",
+}
+
+var configShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Print resolved configuration",
+	RunE:  runConfigShow,
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(configCmd)
+	configCmd.AddCommand(configShowCmd)
+}

--- a/cmd/ow/setup_cmd.go
+++ b/cmd/ow/setup_cmd.go
@@ -1,0 +1,138 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/apt"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/docker"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/nvidia"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/ollama"
+	"github.com/spf13/cobra"
+)
+
+var setupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Full Linux setup: packages, Docker, NVIDIA, Ollama, and OpenWebUI",
+	Long: `Runs the complete setup sequence matching update_open-webui.sh:
+  1. Update system packages
+  2. Setup Docker keyring and install Docker
+  3. Install NVIDIA Container Toolkit
+  4. Configure Docker for NVIDIA and add user to docker group
+  5. Install Ollama
+  6. Verify Docker environment
+  7. Start Ollama container and pull models
+  8. Start OpenWebUI container`,
+	RunE: runSetup,
+}
+
+func init() {
+	rootCmd.AddCommand(setupCmd)
+}
+
+func runSetup(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Resolve(nil)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	logger, err := logging.NewLogger("", logging.Info)
+	if err != nil {
+		return fmt.Errorf("creating logger: %w", err)
+	}
+
+	runner := &exec.RealRunner{Logger: logger}
+	ctx := cmd.Context()
+
+	aptMgr := apt.NewManager(runner, logger)
+	nvInstaller := nvidia.NewInstaller(runner, logger)
+	ollamaMgr := ollama.NewManager(runner, logger)
+	dockerClient := docker.NewClient(runner, logger)
+
+	// Step 1: Update system packages.
+	logger.Info("step 1/11: updating system packages")
+	if err := aptMgr.UpdatePackages(ctx); err != nil {
+		return fmt.Errorf("update packages: %w", err)
+	}
+
+	// Step 2: Setup Docker keyring.
+	logger.Info("step 2/11: setting up Docker keyring")
+	if err := aptMgr.SetupDockerKeyring(ctx); err != nil {
+		return fmt.Errorf("setup docker keyring: %w", err)
+	}
+
+	// Step 3: Install NVIDIA Container Toolkit.
+	logger.Info("step 3/11: installing NVIDIA Container Toolkit")
+	if err := nvInstaller.Install(ctx); err != nil {
+		return fmt.Errorf("install nvidia toolkit: %w", err)
+	}
+
+	// Step 4: Install Docker.
+	logger.Info("step 4/11: installing Docker")
+	if err := aptMgr.InstallDocker(ctx); err != nil {
+		return fmt.Errorf("install docker: %w", err)
+	}
+
+	// Step 5: Configure Docker NVIDIA runtime and add user to docker group.
+	logger.Info("step 5/11: configuring Docker for NVIDIA")
+	if err := aptMgr.ConfigureDockerNvidia(ctx); err != nil {
+		return fmt.Errorf("configure docker nvidia: %w", err)
+	}
+	if err := aptMgr.AddUserToDockerGroup(ctx); err != nil {
+		return fmt.Errorf("add user to docker group: %w", err)
+	}
+
+	// Step 6: Install Ollama.
+	logger.Info("step 6/11: installing Ollama")
+	if err := ollamaMgr.Install(ctx); err != nil {
+		return fmt.Errorf("install ollama: %w", err)
+	}
+
+	// Step 7: Verify Docker environment.
+	logger.Info("step 7/11: verifying Docker environment")
+	if _, err := runner.Run(ctx, "docker", "run", "hello-world"); err != nil {
+		return fmt.Errorf("docker environment verification failed: %w", err)
+	}
+
+	// Step 8: Pull Ollama image and start container.
+	logger.Info("step 8/11: starting Ollama container")
+	ollamaCfg := ollamaContainerConfig(cfg)
+	if err := dockerClient.PullImage(ctx, ollamaCfg.Image, ollamaCfg.Tag); err != nil {
+		return fmt.Errorf("pull ollama image: %w", err)
+	}
+	if err := dockerClient.EnsureRunning(ctx, ollamaCfg); err != nil {
+		return fmt.Errorf("start ollama container: %w", err)
+	}
+
+	// Step 9: Health check Ollama.
+	logger.Info("step 9/11: verifying Ollama health")
+	if err := dockerClient.WaitForHTTP(ctx, cfg.Ollama.Host, cfg.Ollama.Port, "/", exec.DefaultRetryOpts()); err != nil {
+		return fmt.Errorf("ollama health check: %w", err)
+	}
+
+	// Step 10: Pull configured models.
+	logger.Info("step 10/11: pulling Ollama models")
+	if err := ollamaMgr.PullModels(ctx, cfg.Ollama.Models); err != nil {
+		return fmt.Errorf("pull models: %w", err)
+	}
+
+	// Step 11: Pull OpenWebUI image and start container.
+	logger.Info("step 11/11: starting OpenWebUI container")
+	openWebUICfg := openWebUIContainerConfig(cfg)
+	if err := dockerClient.PullImage(ctx, openWebUICfg.Image, openWebUICfg.Tag); err != nil {
+		return fmt.Errorf("pull openwebui image: %w", err)
+	}
+	if err := dockerClient.EnsureRunning(ctx, openWebUICfg); err != nil {
+		return fmt.Errorf("start openwebui container: %w", err)
+	}
+	if err := dockerClient.WaitForHTTP(ctx, cfg.OpenWebUI.Host, cfg.OpenWebUI.Port, "/", exec.DefaultRetryOpts()); err != nil {
+		return fmt.Errorf("openwebui health check: %w", err)
+	}
+
+	logger.Info("setup complete")
+	return nil
+}

--- a/cmd/ow/setup_cmd_test.go
+++ b/cmd/ow/setup_cmd_test.go
@@ -1,0 +1,29 @@
+//go:build linux
+
+package main
+
+import (
+	"testing"
+)
+
+func TestSetupCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "setup" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("setup command not registered on rootCmd")
+	}
+}
+
+func TestSetupCommandDescription(t *testing.T) {
+	if setupCmd.Short == "" {
+		t.Error("setup command has no short description")
+	}
+	if setupCmd.Long == "" {
+		t.Error("setup command has no long description")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,14 @@ go 1.26.1
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.4.0
+	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -8,6 +9,8 @@ github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9L
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -18,6 +21,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
@@ -26,6 +30,9 @@ github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.21.0 h1:x5S+0EU27Lbphp4UKm1C+1oQO+rKx36vfCoaVebLFSU=

--- a/internal/apt/keyring.go
+++ b/internal/apt/keyring.go
@@ -49,11 +49,11 @@ func (m *Manager) SetupDockerKeyring(ctx context.Context) error {
 	}
 
 	// Add Docker repository to sources list.
-	// The actual repo line includes architecture and codename; we use a shell
-	// command to resolve them dynamically.
-	repoLine := "deb [arch=$(dpkg --print-architecture) signed-by=" + dockerKeyringPath + "] " +
-		"https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable"
-	_, err = m.Runner.Run(ctx, "sh", "-c", "echo '"+repoLine+"' > "+dockerSourcesList)
+	// The repo line includes architecture and codename resolved at runtime
+	// via shell command substitution. Double quotes allow expansion.
+	repoLine := `deb [arch=$(dpkg --print-architecture) signed-by=` + dockerKeyringPath + `] ` +
+		`https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable`
+	_, err = m.Runner.Run(ctx, "sh", "-c", `echo "`+repoLine+`" > `+dockerSourcesList)
 	if err != nil {
 		return fmt.Errorf("write docker sources list: %w", err)
 	}

--- a/internal/apt/keyring.go
+++ b/internal/apt/keyring.go
@@ -1,0 +1,151 @@
+//go:build linux
+
+package apt
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/user"
+)
+
+const (
+	dockerKeyringPath = "/etc/apt/keyrings/docker.asc"
+	dockerGPGURL      = "https://download.docker.com/linux/ubuntu/gpg"
+	dockerSourcesList = "/etc/apt/sources.list.d/docker.list"
+
+	nvidiaKeyringPath = "/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+	nvidiaGPGURL      = "https://nvidia.github.io/libnvidia-container/gpgkey"
+	nvidiaSourcesList = "/etc/apt/sources.list.d/nvidia-container-toolkit.list"
+	nvidiaRepoListURL = "https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list"
+)
+
+// SetupDockerKeyring downloads the Docker GPG key and adds the Docker apt
+// repository. Skips if the keyring file already exists.
+func (m *Manager) SetupDockerKeyring(ctx context.Context) error {
+	if _, err := os.Stat(dockerKeyringPath); err == nil {
+		m.Logger.Info("docker keyring already exists at %s, skipping", dockerKeyringPath)
+		return nil
+	}
+
+	m.Logger.Info("setting up Docker GPG keyring and repository")
+
+	// Ensure keyrings directory exists
+	_, err := m.Runner.RunWithRetry(ctx, retryOpts(), "install", "-m", "0755", "-d", "/etc/apt/keyrings")
+	if err != nil {
+		return fmt.Errorf("create keyrings dir: %w", err)
+	}
+
+	// Download Docker GPG key
+	_, err = m.Runner.RunWithRetry(ctx, retryOpts(), "curl", "-fsSL", dockerGPGURL, "-o", dockerKeyringPath)
+	if err != nil {
+		return fmt.Errorf("download docker gpg key: %w", err)
+	}
+
+	// Set permissions on key file
+	_, err = m.Runner.Run(ctx, "chmod", "a+r", dockerKeyringPath)
+	if err != nil {
+		return fmt.Errorf("chmod docker keyring: %w", err)
+	}
+
+	// Add Docker repository to sources list.
+	// The actual repo line includes architecture and codename; we use a shell
+	// command to resolve them dynamically.
+	repoLine := "deb [arch=$(dpkg --print-architecture) signed-by=" + dockerKeyringPath + "] " +
+		"https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable"
+	_, err = m.Runner.Run(ctx, "sh", "-c", "echo '"+repoLine+"' > "+dockerSourcesList)
+	if err != nil {
+		return fmt.Errorf("write docker sources list: %w", err)
+	}
+
+	m.Logger.Info("Docker GPG keyring and repository setup complete")
+	return nil
+}
+
+// SetupNvidiaKeyring downloads the NVIDIA Container Toolkit GPG key and adds
+// the NVIDIA apt repository. Skips if the keyring file already exists.
+func (m *Manager) SetupNvidiaKeyring(ctx context.Context) error {
+	if _, err := os.Stat(nvidiaKeyringPath); err == nil {
+		m.Logger.Info("nvidia keyring already exists at %s, skipping", nvidiaKeyringPath)
+		return nil
+	}
+
+	m.Logger.Info("setting up NVIDIA Container Toolkit GPG keyring")
+
+	// Download and dearmor the NVIDIA GPG key
+	_, err := m.Runner.RunWithRetry(ctx, retryOpts(),
+		"sh", "-c",
+		"curl -fsSL "+nvidiaGPGURL+" | gpg --dearmor --yes -o "+nvidiaKeyringPath)
+	if err != nil {
+		return fmt.Errorf("download nvidia gpg key: %w", err)
+	}
+
+	// Download repo list and add signed-by directive
+	_, err = m.Runner.RunWithRetry(ctx, retryOpts(),
+		"sh", "-c",
+		"curl -s -L "+nvidiaRepoListURL+
+			" | sed 's#deb https://#deb [signed-by="+nvidiaKeyringPath+"] https://#g'"+
+			" > "+nvidiaSourcesList)
+	if err != nil {
+		return fmt.Errorf("write nvidia sources list: %w", err)
+	}
+
+	m.Logger.Info("NVIDIA GPG keyring and repository setup complete")
+	return nil
+}
+
+// InstallDocker installs Docker Engine and related packages.
+func (m *Manager) InstallDocker(ctx context.Context) error {
+	m.Logger.Info("installing Docker")
+
+	// Update package lists first
+	_, err := m.Runner.RunWithRetry(ctx, retryOpts(), "apt-get", "update")
+	if err != nil {
+		return fmt.Errorf("apt-get update: %w", err)
+	}
+
+	return m.InstallPackages(ctx,
+		"docker-ce",
+		"docker-ce-cli",
+		"containerd.io",
+		"docker-buildx-plugin",
+		"docker-compose-plugin",
+	)
+}
+
+// ConfigureDockerNvidia configures the NVIDIA runtime for Docker by running
+// nvidia-ctk and restarting the docker service.
+func (m *Manager) ConfigureDockerNvidia(ctx context.Context) error {
+	m.Logger.Info("configuring Docker NVIDIA runtime")
+
+	_, err := m.Runner.RunWithRetry(ctx, retryOpts(),
+		"nvidia-ctk", "runtime", "configure", "--runtime=docker")
+	if err != nil {
+		return fmt.Errorf("nvidia-ctk configure: %w", err)
+	}
+
+	_, err = m.Runner.RunWithRetry(ctx, retryOpts(), "systemctl", "restart", "docker")
+	if err != nil {
+		return fmt.Errorf("restart docker: %w", err)
+	}
+
+	m.Logger.Info("Docker NVIDIA runtime configured")
+	return nil
+}
+
+// AddUserToDockerGroup adds the current user to the docker group.
+func (m *Manager) AddUserToDockerGroup(ctx context.Context) error {
+	u, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("get current user: %w", err)
+	}
+
+	m.Logger.Info("adding user %s to docker group", u.Username)
+
+	_, err = m.Runner.Run(ctx, "usermod", "-aG", "docker", u.Username)
+	if err != nil {
+		return fmt.Errorf("usermod: %w", err)
+	}
+
+	return nil
+}

--- a/internal/apt/keyring_test.go
+++ b/internal/apt/keyring_test.go
@@ -1,0 +1,293 @@
+//go:build linux
+
+package apt
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+// keyringMockRunner extends mockRunner to support per-call error configuration.
+type keyringMockRunner struct {
+	calls     []mockCall
+	failCalls map[string]error // keyed by "name arg0" or just "name"
+}
+
+func (r *keyringMockRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	r.calls = append(r.calls, mockCall{Name: name, Args: args})
+	key := name
+	if len(args) > 0 {
+		key = name + " " + args[0]
+	}
+	if err, ok := r.failCalls[key]; ok && err != nil {
+		return "", err
+	}
+	if err, ok := r.failCalls[name]; ok && err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+func (r *keyringMockRunner) RunWithRetry(ctx context.Context, opts exec.RetryOpts, name string, args ...string) (string, error) {
+	return r.Run(ctx, name, args...)
+}
+
+func newKeyringTestManager(t *testing.T, runner exec.Runner) *Manager {
+	t.Helper()
+	var buf bytes.Buffer
+	logger, err := logging.NewLoggerWithWriter(&buf, "", logging.Debug2)
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+	return NewManager(runner, logger)
+}
+
+func TestSetupDockerKeyringSkipsWhenExists(t *testing.T) {
+	// Create a temp file to stand in for the keyring
+	tmpDir := t.TempDir()
+	fakeKeyring := filepath.Join(tmpDir, "docker.asc")
+	if err := os.WriteFile(fakeKeyring, []byte("key"), 0600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	// Patch the constant by overriding the check. Since we can't easily
+	// override the const, we test via a helper that takes the path.
+	// Instead, we test the actual function but only when the file exists
+	// at the real path. For unit testing, we verify the mock isn't called.
+	//
+	// We'll test the skip logic indirectly: if the file doesn't exist at
+	// the real path (/etc/apt/keyrings/docker.asc), all commands run.
+	// If it does exist, no commands run.
+	r := &keyringMockRunner{failCalls: map[string]error{}}
+	m := newKeyringTestManager(t, r)
+
+	// Check if the real keyring file exists
+	_, err := os.Stat(dockerKeyringPath)
+	if err == nil {
+		// File exists on this system; setup should be a no-op
+		err = m.SetupDockerKeyring(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("expected 0 calls when keyring exists, got %d", len(r.calls))
+		}
+	} else {
+		// File doesn't exist; setup should run commands
+		err = m.SetupDockerKeyring(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(r.calls) == 0 {
+			t.Error("expected commands to run when keyring is missing")
+		}
+	}
+}
+
+func TestSetupDockerKeyringDownloadsWhenMissing(t *testing.T) {
+	// Skip if the keyring actually exists on this system
+	if _, err := os.Stat(dockerKeyringPath); err == nil {
+		t.Skip("docker keyring exists on this system")
+	}
+
+	r := &keyringMockRunner{failCalls: map[string]error{}}
+	m := newKeyringTestManager(t, r)
+
+	err := m.SetupDockerKeyring(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expect: install (keyrings dir), curl (download key), chmod, sh (write sources)
+	if len(r.calls) < 4 {
+		t.Fatalf("expected at least 4 calls, got %d: %v", len(r.calls), r.calls)
+	}
+
+	// First call: create keyrings directory
+	if r.calls[0].Name != "install" {
+		t.Errorf("call 0: name = %q, want %q", r.calls[0].Name, "install")
+	}
+
+	// Second call: curl to download GPG key
+	if r.calls[1].Name != "curl" {
+		t.Errorf("call 1: name = %q, want %q", r.calls[1].Name, "curl")
+	}
+
+	// Third call: chmod
+	if r.calls[2].Name != "chmod" {
+		t.Errorf("call 2: name = %q, want %q", r.calls[2].Name, "chmod")
+	}
+
+	// Fourth call: sh to write sources list
+	if r.calls[3].Name != "sh" {
+		t.Errorf("call 3: name = %q, want %q", r.calls[3].Name, "sh")
+	}
+}
+
+func TestSetupNvidiaKeyringSkipsWhenExists(t *testing.T) {
+	if _, err := os.Stat(nvidiaKeyringPath); err != nil {
+		t.Skip("nvidia keyring does not exist on this system")
+	}
+
+	r := &keyringMockRunner{failCalls: map[string]error{}}
+	m := newKeyringTestManager(t, r)
+
+	err := m.SetupNvidiaKeyring(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("expected 0 calls when keyring exists, got %d", len(r.calls))
+	}
+}
+
+func TestSetupNvidiaKeyringDownloadsWhenMissing(t *testing.T) {
+	if _, err := os.Stat(nvidiaKeyringPath); err == nil {
+		t.Skip("nvidia keyring exists on this system")
+	}
+
+	r := &keyringMockRunner{failCalls: map[string]error{}}
+	m := newKeyringTestManager(t, r)
+
+	err := m.SetupNvidiaKeyring(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expect: sh (curl + gpg dearmor), sh (curl + sed for repo list)
+	if len(r.calls) < 2 {
+		t.Fatalf("expected at least 2 calls, got %d: %v", len(r.calls), r.calls)
+	}
+
+	// Both calls should be via sh -c
+	for i, call := range r.calls {
+		if call.Name != "sh" {
+			t.Errorf("call %d: name = %q, want %q", i, call.Name, "sh")
+		}
+	}
+}
+
+func TestInstallDockerPassesCorrectPackages(t *testing.T) {
+	r := &keyringMockRunner{failCalls: map[string]error{}}
+	m := newKeyringTestManager(t, r)
+
+	err := m.InstallDocker(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expect: apt-get update, apt-get install with docker packages
+	if len(r.calls) < 2 {
+		t.Fatalf("expected at least 2 calls, got %d", len(r.calls))
+	}
+
+	// First: apt-get update
+	if r.calls[0].Name != "apt-get" || r.calls[0].Args[0] != "update" {
+		t.Errorf("call 0: got %s %v, want apt-get update", r.calls[0].Name, r.calls[0].Args)
+	}
+
+	// Second: apt-get install with all docker packages
+	installCall := r.calls[1]
+	if installCall.Name != "apt-get" {
+		t.Errorf("call 1: name = %q, want %q", installCall.Name, "apt-get")
+	}
+
+	wantPkgs := []string{"docker-ce", "docker-ce-cli", "containerd.io", "docker-buildx-plugin", "docker-compose-plugin"}
+	argsStr := strings.Join(installCall.Args, " ")
+	for _, pkg := range wantPkgs {
+		if !strings.Contains(argsStr, pkg) {
+			t.Errorf("install args missing package %q, got: %v", pkg, installCall.Args)
+		}
+	}
+}
+
+func TestConfigureDockerNvidiaWritesConfigAndRestarts(t *testing.T) {
+	r := &keyringMockRunner{failCalls: map[string]error{}}
+	m := newKeyringTestManager(t, r)
+
+	err := m.ConfigureDockerNvidia(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(r.calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d: %v", len(r.calls), r.calls)
+	}
+
+	// First: nvidia-ctk configure
+	if r.calls[0].Name != "nvidia-ctk" {
+		t.Errorf("call 0: name = %q, want %q", r.calls[0].Name, "nvidia-ctk")
+	}
+	argsStr := strings.Join(r.calls[0].Args, " ")
+	if !strings.Contains(argsStr, "--runtime=docker") {
+		t.Errorf("nvidia-ctk args missing --runtime=docker, got: %v", r.calls[0].Args)
+	}
+
+	// Second: systemctl restart docker
+	if r.calls[1].Name != "systemctl" {
+		t.Errorf("call 1: name = %q, want %q", r.calls[1].Name, "systemctl")
+	}
+	if len(r.calls[1].Args) < 2 || r.calls[1].Args[0] != "restart" || r.calls[1].Args[1] != "docker" {
+		t.Errorf("call 1: args = %v, want [restart docker]", r.calls[1].Args)
+	}
+}
+
+func TestAddUserToDockerGroupRunsUsermod(t *testing.T) {
+	r := &keyringMockRunner{failCalls: map[string]error{}}
+	m := newKeyringTestManager(t, r)
+
+	err := m.AddUserToDockerGroup(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(r.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(r.calls))
+	}
+
+	call := r.calls[0]
+	if call.Name != "usermod" {
+		t.Errorf("name = %q, want %q", call.Name, "usermod")
+	}
+	if len(call.Args) < 3 || call.Args[0] != "-aG" || call.Args[1] != "docker" {
+		t.Errorf("args = %v, want [-aG docker <username>]", call.Args)
+	}
+}
+
+func TestConfigureDockerNvidiaErrorOnConfigure(t *testing.T) {
+	r := &keyringMockRunner{failCalls: map[string]error{
+		"nvidia-ctk": fmt.Errorf("nvidia-ctk not found"),
+	}}
+	m := newKeyringTestManager(t, r)
+
+	err := m.ConfigureDockerNvidia(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "nvidia-ctk") {
+		t.Errorf("error = %q, want it to contain 'nvidia-ctk'", err.Error())
+	}
+}
+
+func TestInstallDockerErrorOnUpdate(t *testing.T) {
+	r := &keyringMockRunner{failCalls: map[string]error{
+		"apt-get": fmt.Errorf("network error"),
+	}}
+	m := newKeyringTestManager(t, r)
+
+	err := m.InstallDocker(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "network error") {
+		t.Errorf("error = %q, want it to contain 'network error'", err.Error())
+	}
+}

--- a/internal/apt/keyring_test.go
+++ b/internal/apt/keyring_test.go
@@ -184,7 +184,7 @@ func TestInstallDockerPassesCorrectPackages(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Expect: apt-get update, apt-get install with docker packages
+	// Expect: apt-get update, sh -c "DEBIAN_FRONTEND=noninteractive apt-get install ..."
 	if len(r.calls) < 2 {
 		t.Fatalf("expected at least 2 calls, got %d", len(r.calls))
 	}
@@ -194,10 +194,10 @@ func TestInstallDockerPassesCorrectPackages(t *testing.T) {
 		t.Errorf("call 0: got %s %v, want apt-get update", r.calls[0].Name, r.calls[0].Args)
 	}
 
-	// Second: apt-get install with all docker packages
+	// Second: sh -c with DEBIAN_FRONTEND and all docker packages
 	installCall := r.calls[1]
-	if installCall.Name != "apt-get" {
-		t.Errorf("call 1: name = %q, want %q", installCall.Name, "apt-get")
+	if installCall.Name != "sh" {
+		t.Errorf("call 1: name = %q, want %q", installCall.Name, "sh")
 	}
 
 	wantPkgs := []string{"docker-ce", "docker-ce-cli", "containerd.io", "docker-buildx-plugin", "docker-compose-plugin"}

--- a/internal/apt/packages.go
+++ b/internal/apt/packages.go
@@ -1,0 +1,84 @@
+//go:build linux
+
+// Package apt manages system packages and GPG keyring setup on Ubuntu/Debian.
+// It shells out via the exec.Runner interface.
+package apt
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+// Manager handles apt package operations and keyring setup.
+type Manager struct {
+	Runner exec.Runner
+	Logger *logging.Logger
+}
+
+// NewManager creates a Manager with the given runner and logger.
+func NewManager(runner exec.Runner, logger *logging.Logger) *Manager {
+	return &Manager{
+		Runner: runner,
+		Logger: logger,
+	}
+}
+
+// retryOpts returns the standard retry options for apt operations.
+func retryOpts() exec.RetryOpts {
+	return exec.DefaultRetryOpts()
+}
+
+// UpdatePackages runs apt-get update, upgrade, dist-upgrade, autoremove, and
+// autoclean with retry on each step. Sets DEBIAN_FRONTEND=noninteractive via
+// env args passed to apt-get.
+func (m *Manager) UpdatePackages(ctx context.Context) error {
+	m.Logger.Info("updating system packages")
+
+	commands := [][]string{
+		{"apt-get", "update"},
+		{"apt-get", "upgrade", "-y"},
+		{"apt-get", "dist-upgrade", "-y"},
+		{"apt-get", "autoremove", "-y"},
+		{"apt-get", "autoclean", "-y"},
+	}
+
+	for _, cmd := range commands {
+		_, err := m.Runner.RunWithRetry(ctx, retryOpts(), cmd[0], cmd[1:]...)
+		if err != nil {
+			return fmt.Errorf("%s: %w", cmd[0]+" "+cmd[1], err)
+		}
+	}
+
+	m.Logger.Info("system packages updated")
+	return nil
+}
+
+// InstallPackages installs the given packages via apt-get install -y with retry.
+func (m *Manager) InstallPackages(ctx context.Context, pkgs ...string) error {
+	if len(pkgs) == 0 {
+		return fmt.Errorf("no packages specified")
+	}
+
+	m.Logger.Info("installing packages: %v", pkgs)
+
+	args := append([]string{"install", "-y"}, pkgs...)
+	_, err := m.Runner.RunWithRetry(ctx, retryOpts(), "apt-get", args...)
+	if err != nil {
+		return fmt.Errorf("apt-get install: %w", err)
+	}
+
+	m.Logger.Info("packages installed: %v", pkgs)
+	return nil
+}
+
+// IsInstalled checks whether a package is installed by running dpkg -l.
+func (m *Manager) IsInstalled(ctx context.Context, pkg string) (bool, error) {
+	_, err := m.Runner.Run(ctx, "dpkg", "-l", pkg)
+	if err != nil {
+		return false, nil //nolint:nilerr // dpkg returns non-zero when package is not installed
+	}
+	return true, nil
+}

--- a/internal/apt/packages.go
+++ b/internal/apt/packages.go
@@ -32,23 +32,23 @@ func retryOpts() exec.RetryOpts {
 }
 
 // UpdatePackages runs apt-get update, upgrade, dist-upgrade, autoremove, and
-// autoclean with retry on each step. Sets DEBIAN_FRONTEND=noninteractive via
-// env args passed to apt-get.
+// autoclean with retry on each step. Uses DEBIAN_FRONTEND=noninteractive
+// to suppress interactive prompts during upgrades.
 func (m *Manager) UpdatePackages(ctx context.Context) error {
 	m.Logger.Info("updating system packages")
 
 	commands := [][]string{
-		{"apt-get", "update"},
-		{"apt-get", "upgrade", "-y"},
-		{"apt-get", "dist-upgrade", "-y"},
-		{"apt-get", "autoremove", "-y"},
-		{"apt-get", "autoclean", "-y"},
+		{"sh", "-c", "apt-get update"},
+		{"sh", "-c", "DEBIAN_FRONTEND=noninteractive apt-get upgrade -y"},
+		{"sh", "-c", "DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y"},
+		{"sh", "-c", "apt-get autoremove -y"},
+		{"sh", "-c", "apt-get autoclean -y"},
 	}
 
 	for _, cmd := range commands {
 		_, err := m.Runner.RunWithRetry(ctx, retryOpts(), cmd[0], cmd[1:]...)
 		if err != nil {
-			return fmt.Errorf("%s: %w", cmd[0]+" "+cmd[1], err)
+			return fmt.Errorf("%s: %w", cmd[2], err)
 		}
 	}
 
@@ -57,6 +57,7 @@ func (m *Manager) UpdatePackages(ctx context.Context) error {
 }
 
 // InstallPackages installs the given packages via apt-get install -y with retry.
+// Uses DEBIAN_FRONTEND=noninteractive to suppress interactive prompts.
 func (m *Manager) InstallPackages(ctx context.Context, pkgs ...string) error {
 	if len(pkgs) == 0 {
 		return fmt.Errorf("no packages specified")
@@ -64,8 +65,11 @@ func (m *Manager) InstallPackages(ctx context.Context, pkgs ...string) error {
 
 	m.Logger.Info("installing packages: %v", pkgs)
 
-	args := append([]string{"install", "-y"}, pkgs...)
-	_, err := m.Runner.RunWithRetry(ctx, retryOpts(), "apt-get", args...)
+	shellCmd := "DEBIAN_FRONTEND=noninteractive apt-get install -y"
+	for _, pkg := range pkgs {
+		shellCmd += " " + pkg
+	}
+	_, err := m.Runner.RunWithRetry(ctx, retryOpts(), "sh", "-c", shellCmd)
 	if err != nil {
 		return fmt.Errorf("apt-get install: %w", err)
 	}

--- a/internal/apt/packages_test.go
+++ b/internal/apt/packages_test.go
@@ -1,0 +1,198 @@
+//go:build linux
+
+package apt
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+// mockCall records a single command invocation.
+type mockCall struct {
+	Name string
+	Args []string
+}
+
+// mockRunner records commands and returns preconfigured results.
+type mockRunner struct {
+	calls  []mockCall
+	errors map[string]error // keyed by command name; nil means success
+}
+
+func (r *mockRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	r.calls = append(r.calls, mockCall{Name: name, Args: args})
+	if err, ok := r.errors[name]; ok && err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+func (r *mockRunner) RunWithRetry(ctx context.Context, opts exec.RetryOpts, name string, args ...string) (string, error) {
+	return r.Run(ctx, name, args...)
+}
+
+func newTestManager(t *testing.T, runner *mockRunner) *Manager {
+	t.Helper()
+	var buf bytes.Buffer
+	logger, err := logging.NewLoggerWithWriter(&buf, "", logging.Debug2)
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+	return NewManager(runner, logger)
+}
+
+func TestUpdatePackagesRunsAllCommands(t *testing.T) {
+	r := &mockRunner{errors: map[string]error{}}
+	m := newTestManager(t, r)
+
+	err := m.UpdatePackages(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{"update", "upgrade", "dist-upgrade", "autoremove", "autoclean"}
+	if len(r.calls) != len(expected) {
+		t.Fatalf("got %d calls, want %d", len(r.calls), len(expected))
+	}
+	for i, want := range expected {
+		if r.calls[i].Name != "apt-get" {
+			t.Errorf("call %d: name = %q, want %q", i, r.calls[i].Name, "apt-get")
+		}
+		if r.calls[i].Args[0] != want {
+			t.Errorf("call %d: first arg = %q, want %q", i, r.calls[i].Args[0], want)
+		}
+	}
+}
+
+func TestInstallPackagesPassesNames(t *testing.T) {
+	r := &mockRunner{errors: map[string]error{}}
+	m := newTestManager(t, r)
+
+	err := m.InstallPackages(context.Background(), "vim", "git", "curl")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(r.calls) != 1 {
+		t.Fatalf("got %d calls, want 1", len(r.calls))
+	}
+	call := r.calls[0]
+	if call.Name != "apt-get" {
+		t.Errorf("name = %q, want %q", call.Name, "apt-get")
+	}
+	// Args should be: install -y vim git curl
+	wantArgs := []string{"install", "-y", "vim", "git", "curl"}
+	if len(call.Args) != len(wantArgs) {
+		t.Fatalf("args = %v, want %v", call.Args, wantArgs)
+	}
+	for i, want := range wantArgs {
+		if call.Args[i] != want {
+			t.Errorf("arg %d = %q, want %q", i, call.Args[i], want)
+		}
+	}
+}
+
+func TestIsInstalledReturnsTrueOnSuccess(t *testing.T) {
+	r := &mockRunner{errors: map[string]error{}}
+	m := newTestManager(t, r)
+
+	installed, err := m.IsInstalled(context.Background(), "vim")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !installed {
+		t.Error("expected true, got false")
+	}
+
+	if len(r.calls) != 1 || r.calls[0].Name != "dpkg" {
+		t.Errorf("expected dpkg call, got %v", r.calls)
+	}
+}
+
+func TestIsInstalledReturnsFalseOnFailure(t *testing.T) {
+	r := &mockRunner{errors: map[string]error{
+		"dpkg": fmt.Errorf("no packages found matching vim"),
+	}}
+	m := newTestManager(t, r)
+
+	installed, err := m.IsInstalled(context.Background(), "vim")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if installed {
+		t.Error("expected false, got true")
+	}
+}
+
+func TestUpdatePackagesUsesRunWithRetry(t *testing.T) {
+	// Verify that RunWithRetry is called (not Run) by checking that
+	// the mock's RunWithRetry path is exercised. We use a specialized
+	// mock that tracks which method was called.
+	retryRunner := &retryTrackingRunner{errors: map[string]error{}}
+	var buf bytes.Buffer
+	logger, err := logging.NewLoggerWithWriter(&buf, "", logging.Debug2)
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+	m := NewManager(retryRunner, logger)
+
+	err = m.UpdatePackages(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if retryRunner.retryCount != 5 {
+		t.Errorf("RunWithRetry called %d times, want 5", retryRunner.retryCount)
+	}
+	if retryRunner.runCount != 0 {
+		t.Errorf("Run called %d times, want 0", retryRunner.runCount)
+	}
+}
+
+func TestUpdatePackagesStopsOnError(t *testing.T) {
+	r := &mockRunner{errors: map[string]error{
+		"apt-get": fmt.Errorf("lock held"),
+	}}
+	m := newTestManager(t, r)
+
+	err := m.UpdatePackages(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "lock held") {
+		t.Errorf("error = %q, want it to contain 'lock held'", err.Error())
+	}
+	// Should stop after first failed command
+	if len(r.calls) != 1 {
+		t.Errorf("got %d calls, want 1 (should stop on first failure)", len(r.calls))
+	}
+}
+
+// retryTrackingRunner counts calls to Run vs RunWithRetry.
+type retryTrackingRunner struct {
+	runCount   int
+	retryCount int
+	errors     map[string]error
+}
+
+func (r *retryTrackingRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	r.runCount++
+	if err, ok := r.errors[name]; ok && err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+func (r *retryTrackingRunner) RunWithRetry(ctx context.Context, opts exec.RetryOpts, name string, args ...string) (string, error) {
+	r.retryCount++
+	if err, ok := r.errors[name]; ok && err != nil {
+		return "", err
+	}
+	return "", nil
+}

--- a/internal/apt/packages_test.go
+++ b/internal/apt/packages_test.go
@@ -56,16 +56,27 @@ func TestUpdatePackagesRunsAllCommands(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := []string{"update", "upgrade", "dist-upgrade", "autoremove", "autoclean"}
+	expected := []string{
+		"apt-get update",
+		"DEBIAN_FRONTEND=noninteractive apt-get upgrade -y",
+		"DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y",
+		"apt-get autoremove -y",
+		"apt-get autoclean -y",
+	}
 	if len(r.calls) != len(expected) {
 		t.Fatalf("got %d calls, want %d", len(r.calls), len(expected))
 	}
 	for i, want := range expected {
-		if r.calls[i].Name != "apt-get" {
-			t.Errorf("call %d: name = %q, want %q", i, r.calls[i].Name, "apt-get")
+		if r.calls[i].Name != "sh" {
+			t.Errorf("call %d: name = %q, want %q", i, r.calls[i].Name, "sh")
 		}
-		if r.calls[i].Args[0] != want {
-			t.Errorf("call %d: first arg = %q, want %q", i, r.calls[i].Args[0], want)
+		// Args should be ["-c", <shell command>]
+		if len(r.calls[i].Args) != 2 || r.calls[i].Args[0] != "-c" {
+			t.Errorf("call %d: args = %v, want [\"-c\", ...]", i, r.calls[i].Args)
+			continue
+		}
+		if r.calls[i].Args[1] != want {
+			t.Errorf("call %d: shell cmd = %q, want %q", i, r.calls[i].Args[1], want)
 		}
 	}
 }
@@ -83,18 +94,16 @@ func TestInstallPackagesPassesNames(t *testing.T) {
 		t.Fatalf("got %d calls, want 1", len(r.calls))
 	}
 	call := r.calls[0]
-	if call.Name != "apt-get" {
-		t.Errorf("name = %q, want %q", call.Name, "apt-get")
+	if call.Name != "sh" {
+		t.Errorf("name = %q, want %q", call.Name, "sh")
 	}
-	// Args should be: install -y vim git curl
-	wantArgs := []string{"install", "-y", "vim", "git", "curl"}
-	if len(call.Args) != len(wantArgs) {
-		t.Fatalf("args = %v, want %v", call.Args, wantArgs)
+	// Args should be: -c "DEBIAN_FRONTEND=noninteractive apt-get install -y vim git curl"
+	wantShellCmd := "DEBIAN_FRONTEND=noninteractive apt-get install -y vim git curl"
+	if len(call.Args) != 2 || call.Args[0] != "-c" {
+		t.Fatalf("args = %v, want [\"-c\", %q]", call.Args, wantShellCmd)
 	}
-	for i, want := range wantArgs {
-		if call.Args[i] != want {
-			t.Errorf("arg %d = %q, want %q", i, call.Args[i], want)
-		}
+	if call.Args[1] != wantShellCmd {
+		t.Errorf("shell cmd = %q, want %q", call.Args[1], wantShellCmd)
 	}
 }
 
@@ -157,7 +166,7 @@ func TestUpdatePackagesUsesRunWithRetry(t *testing.T) {
 
 func TestUpdatePackagesStopsOnError(t *testing.T) {
 	r := &mockRunner{errors: map[string]error{
-		"apt-get": fmt.Errorf("lock held"),
+		"sh": fmt.Errorf("lock held"),
 	}}
 	m := newTestManager(t, r)
 

--- a/internal/config/defaults_parity_test.go
+++ b/internal/config/defaults_parity_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestDefaultsMatchBashConfig parses update_open-webui.config.sh and asserts
+// that every Bash default matches the Go Defaults() struct. This is a guardrail
+// test that catches config drift between the two systems during side-by-side
+// operation.
+//
+// This test has NO runtime dependency on Bash. It parses the config file as
+// text using simple regex matching.
+func TestDefaultsMatchBashConfig(t *testing.T) {
+	bashCfgPath := "../../update_open-webui.config.sh"
+	data, err := os.ReadFile(bashCfgPath)
+	if err != nil {
+		t.Fatalf("reading bash config: %v", err)
+	}
+
+	bashVars := parseBashConfig(string(data))
+	defaults := Defaults()
+
+	// Ollama settings.
+	assertIntMatch(t, bashVars, "OLLAMA_PORT", defaults.Ollama.Port)
+	assertStringMatch(t, bashVars, "OLLAMA_HOST", defaults.Ollama.Host)
+	assertStringMatch(t, bashVars, "OLLAMA_CONTAINER_TAG", defaults.Ollama.Tag)
+	assertStringMatch(t, bashVars, "OLLAMA_CONTAINER_NAME", defaults.Ollama.Container)
+	assertStringMatch(t, bashVars, "OLLAMA_VOLUME_NAME", defaults.Ollama.Volume)
+
+	// OpenWebUI settings.
+	assertIntMatch(t, bashVars, "OPEN_WEBUI_PORT", defaults.OpenWebUI.Port)
+	assertStringMatch(t, bashVars, "OPEN_WEBUI_HOST", defaults.OpenWebUI.Host)
+	assertStringMatch(t, bashVars, "OPEN_WEBUI_CONTAINER_TAG", defaults.OpenWebUI.Tag)
+	assertStringMatch(t, bashVars, "OPEN_WEBUI_CONTAINER_NAME", defaults.OpenWebUI.Container)
+	assertStringMatch(t, bashVars, "OPEN_WEBUI_VOLUME_NAME", defaults.OpenWebUI.Volume)
+
+	// Models.
+	bashModels := parseBashArray(string(data), "DEFAULT_OLLAMA_MODELS")
+	if len(bashModels) != len(defaults.Ollama.Models) {
+		t.Fatalf("model count mismatch: bash=%d, go=%d", len(bashModels), len(defaults.Ollama.Models))
+	}
+	for i, model := range bashModels {
+		if model != defaults.Ollama.Models[i] {
+			t.Errorf("model[%d]: bash=%q, go=%q", i, model, defaults.Ollama.Models[i])
+		}
+	}
+}
+
+// parseBashConfig extracts KEY=VALUE pairs from a Bash config file.
+// Handles both quoted and unquoted values.
+func parseBashConfig(content string) map[string]string {
+	vars := make(map[string]string)
+	re := regexp.MustCompile(`^([A-Z_]+)=["']?([^"'\n]*)["']?`)
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if m := re.FindStringSubmatch(line); m != nil {
+			vars[m[1]] = m[2]
+		}
+	}
+	return vars
+}
+
+// parseBashArray extracts values from a Bash array declaration like:
+//
+//	ARRAY_NAME=(
+//	    "value1"
+//	    "value2"
+//	)
+func parseBashArray(content string, name string) []string {
+	re := regexp.MustCompile(name + `=\(\s*\n([\s\S]*?)\)`)
+	m := re.FindStringSubmatch(content)
+	if m == nil {
+		return nil
+	}
+
+	var values []string
+	valRe := regexp.MustCompile(`"([^"]+)"`)
+	for _, match := range valRe.FindAllStringSubmatch(m[1], -1) {
+		values = append(values, match[1])
+	}
+	return values
+}
+
+func assertStringMatch(t *testing.T, bashVars map[string]string, key string, goVal string) {
+	t.Helper()
+	bashVal, ok := bashVars[key]
+	if !ok {
+		t.Errorf("bash config missing key %s", key)
+		return
+	}
+	if bashVal != goVal {
+		t.Errorf("%s: bash=%q, go=%q", key, bashVal, goVal)
+	}
+}
+
+func assertIntMatch(t *testing.T, bashVars map[string]string, key string, goVal int) {
+	t.Helper()
+	bashVal, ok := bashVars[key]
+	if !ok {
+		t.Errorf("bash config missing key %s", key)
+		return
+	}
+	bashInt, err := strconv.Atoi(bashVal)
+	if err != nil {
+		t.Errorf("%s: bash value %q is not an integer", key, bashVal)
+		return
+	}
+	if bashInt != goVal {
+		t.Errorf("%s: bash=%d, go=%d", key, bashInt, goVal)
+	}
+}

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -26,10 +26,12 @@ func NewClient(runner exec.Runner, logger *logging.Logger) *Client {
 // ContainerExists returns true if a container with the given name exists
 // (running or stopped). It runs `docker inspect name`.
 func (c *Client) ContainerExists(ctx context.Context, name string) (bool, error) {
-	_, err := c.Runner.Run(ctx, "docker", "inspect", name)
+	output, err := c.Runner.Run(ctx, "docker", "inspect", name)
 	if err != nil {
-		// docker inspect exits non-zero when the container does not exist.
-		if strings.Contains(err.Error(), "failed") {
+		// docker inspect exits non-zero with "No such object" when the
+		// container does not exist. Any other error is a real failure.
+		if strings.Contains(output, "No such object") ||
+			strings.Contains(output, "No such container") {
 			return false, nil
 		}
 		return false, err
@@ -42,8 +44,10 @@ func (c *Client) ContainerExists(ctx context.Context, name string) (bool, error)
 func (c *Client) ContainerIsRunning(ctx context.Context, name string) (bool, error) {
 	out, err := c.Runner.Run(ctx, "docker", "inspect", "-f", "{{.State.Running}}", name)
 	if err != nil {
-		// Container does not exist or inspect failed.
-		if strings.Contains(err.Error(), "failed") {
+		// docker inspect exits non-zero with "No such object" when the
+		// container does not exist. Any other error is a real failure.
+		if strings.Contains(out, "No such object") ||
+			strings.Contains(out, "No such container") {
 			return false, nil
 		}
 		return false, err

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -1,0 +1,155 @@
+//go:build linux
+
+package docker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+// Client manages Docker container lifecycle by shelling out to the docker CLI.
+type Client struct {
+	Runner exec.Runner
+	Logger *logging.Logger
+}
+
+// NewClient creates a Client with the given runner and logger.
+func NewClient(runner exec.Runner, logger *logging.Logger) *Client {
+	return &Client{Runner: runner, Logger: logger}
+}
+
+// ContainerExists returns true if a container with the given name exists
+// (running or stopped). It runs `docker inspect name`.
+func (c *Client) ContainerExists(ctx context.Context, name string) (bool, error) {
+	_, err := c.Runner.Run(ctx, "docker", "inspect", name)
+	if err != nil {
+		// docker inspect exits non-zero when the container does not exist.
+		if strings.Contains(err.Error(), "failed") {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// ContainerIsRunning returns true if a container with the given name exists
+// and is currently running.
+func (c *Client) ContainerIsRunning(ctx context.Context, name string) (bool, error) {
+	out, err := c.Runner.Run(ctx, "docker", "inspect", "-f", "{{.State.Running}}", name)
+	if err != nil {
+		// Container does not exist or inspect failed.
+		if strings.Contains(err.Error(), "failed") {
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.TrimSpace(out) == "true", nil
+}
+
+// StopContainer stops a running container. If the container is not running,
+// this is a no-op.
+func (c *Client) StopContainer(ctx context.Context, name string) error {
+	running, err := c.ContainerIsRunning(ctx, name)
+	if err != nil {
+		return fmt.Errorf("check running state: %w", err)
+	}
+	if !running {
+		c.Logger.Info("container %s is not running, skipping stop", name)
+		return nil
+	}
+	c.Logger.Info("stopping container %s", name)
+	_, err = c.Runner.Run(ctx, "docker", "stop", name)
+	return err
+}
+
+// RemoveContainer removes a container. If the container does not exist,
+// this is a no-op.
+func (c *Client) RemoveContainer(ctx context.Context, name string) error {
+	exists, err := c.ContainerExists(ctx, name)
+	if err != nil {
+		return fmt.Errorf("check existence: %w", err)
+	}
+	if !exists {
+		c.Logger.Info("container %s does not exist, skipping remove", name)
+		return nil
+	}
+	c.Logger.Info("removing container %s", name)
+	_, err = c.Runner.Run(ctx, "docker", "rm", name)
+	return err
+}
+
+// StopAndRemove stops and removes a container. Both operations are idempotent.
+func (c *Client) StopAndRemove(ctx context.Context, name string) error {
+	if err := c.StopContainer(ctx, name); err != nil {
+		return fmt.Errorf("stop %s: %w", name, err)
+	}
+	if err := c.RemoveContainer(ctx, name); err != nil {
+		return fmt.Errorf("remove %s: %w", name, err)
+	}
+	return nil
+}
+
+// PullImage pulls a Docker image using the runner's retry mechanism.
+func (c *Client) PullImage(ctx context.Context, image, tag string) error {
+	ref := image + ":" + tag
+	c.Logger.Info("pulling image %s", ref)
+	_, err := c.Runner.RunWithRetry(ctx, exec.DefaultRetryOpts(), "docker", "pull", ref)
+	return err
+}
+
+// RunContainer starts a new container from the given config.
+func (c *Client) RunContainer(ctx context.Context, cfg ContainerConfig) error {
+	c.Logger.Info("running container %s from %s", cfg.Name, cfg.ImageRef())
+	args := cfg.RunArgs()
+	_, err := c.Runner.Run(ctx, "docker", args...)
+	return err
+}
+
+// EnsureRunning stops and removes any existing container, runs a new one,
+// and polls until it reports as running.
+func (c *Client) EnsureRunning(ctx context.Context, cfg ContainerConfig) error {
+	if err := c.StopAndRemove(ctx, cfg.Name); err != nil {
+		return err
+	}
+	if err := c.RunContainer(ctx, cfg); err != nil {
+		return err
+	}
+
+	// Poll until the container is running.
+	opts := exec.DefaultRetryOpts()
+	a := opts.InitialA
+	b := opts.InitialB
+
+	for attempt := 1; attempt <= opts.MaxAttempts; attempt++ {
+		running, err := c.ContainerIsRunning(ctx, cfg.Name)
+		if err != nil {
+			return fmt.Errorf("poll running state: %w", err)
+		}
+		if running {
+			c.Logger.Info("container %s is running", cfg.Name)
+			return nil
+		}
+
+		if attempt == opts.MaxAttempts {
+			break
+		}
+
+		var delay time.Duration
+		delay, a, b = exec.NextDelay(a, b)
+		c.Logger.Warn("container %s not yet running, retry %d/%d in %s",
+			cfg.Name, attempt, opts.MaxAttempts, delay)
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled waiting for %s: %w", cfg.Name, ctx.Err())
+		case <-time.After(delay):
+		}
+	}
+
+	return fmt.Errorf("container %s not running after %d attempts", cfg.Name, opts.MaxAttempts)
+}

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -1,0 +1,323 @@
+//go:build linux
+
+package docker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+// mockCall represents one expected call to the mock runner.
+type mockCall struct {
+	wantName string
+	wantArgs []string // nil means don't check args
+	output   string
+	err      error
+}
+
+// mockRunner replays predefined responses for sequential calls.
+type mockRunner struct {
+	calls   []mockCall
+	current int
+	t       *testing.T
+}
+
+func (m *mockRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	m.t.Helper()
+	if m.current >= len(m.calls) {
+		m.t.Fatalf("unexpected call #%d: %s %v", m.current, name, args)
+	}
+	c := m.calls[m.current]
+	m.current++
+
+	if c.wantName != "" && c.wantName != name {
+		m.t.Errorf("call #%d: name = %q, want %q", m.current-1, name, c.wantName)
+	}
+	if c.wantArgs != nil {
+		got := strings.Join(args, " ")
+		want := strings.Join(c.wantArgs, " ")
+		if got != want {
+			m.t.Errorf("call #%d: args = %q, want %q", m.current-1, got, want)
+		}
+	}
+	return c.output, c.err
+}
+
+func (m *mockRunner) RunWithRetry(ctx context.Context, opts exec.RetryOpts, name string, args ...string) (string, error) {
+	// For test purposes, just delegate to Run (retry logic is tested in exec).
+	return m.Run(ctx, name, args...)
+}
+
+func (m *mockRunner) verify() {
+	m.t.Helper()
+	if m.current != len(m.calls) {
+		m.t.Errorf("expected %d calls, got %d", len(m.calls), m.current)
+	}
+}
+
+func newTestClient(t *testing.T, calls []mockCall) (*Client, *mockRunner) {
+	t.Helper()
+	var buf bytes.Buffer
+	logger, err := logging.NewLoggerWithWriter(&buf, "", logging.Debug2)
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+	mr := &mockRunner{calls: calls, t: t}
+	return NewClient(mr, logger), mr
+}
+
+func TestContainerExistsTrue(t *testing.T) {
+	c, m := newTestClient(t, []mockCall{
+		{wantName: "docker", wantArgs: []string{"inspect", "ollama"}, output: "{}", err: nil},
+	})
+	exists, err := c.ContainerExists(context.Background(), "ollama")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Error("ContainerExists = false, want true")
+	}
+	m.verify()
+}
+
+func TestContainerExistsFalse(t *testing.T) {
+	c, m := newTestClient(t, []mockCall{
+		{wantName: "docker", wantArgs: []string{"inspect", "missing"},
+			output: "", err: fmt.Errorf("command \"docker\" failed: no such container")},
+	})
+	exists, err := c.ContainerExists(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exists {
+		t.Error("ContainerExists = true, want false")
+	}
+	m.verify()
+}
+
+func TestContainerIsRunningTrue(t *testing.T) {
+	c, m := newTestClient(t, []mockCall{
+		{wantName: "docker", wantArgs: []string{"inspect", "-f", "{{.State.Running}}", "ollama"},
+			output: "true\n", err: nil},
+	})
+	running, err := c.ContainerIsRunning(context.Background(), "ollama")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !running {
+		t.Error("ContainerIsRunning = false, want true")
+	}
+	m.verify()
+}
+
+func TestContainerIsRunningFalse(t *testing.T) {
+	c, m := newTestClient(t, []mockCall{
+		{wantName: "docker", wantArgs: []string{"inspect", "-f", "{{.State.Running}}", "ollama"},
+			output: "false\n", err: nil},
+	})
+	running, err := c.ContainerIsRunning(context.Background(), "ollama")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if running {
+		t.Error("ContainerIsRunning = true, want false")
+	}
+	m.verify()
+}
+
+func TestStopContainerSkipsWhenNotRunning(t *testing.T) {
+	c, m := newTestClient(t, []mockCall{
+		// ContainerIsRunning check: returns false.
+		{wantName: "docker", wantArgs: []string{"inspect", "-f", "{{.State.Running}}", "myapp"},
+			output: "false\n", err: nil},
+	})
+	err := c.StopContainer(context.Background(), "myapp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m.verify()
+}
+
+func TestStopContainerCallsDockerStop(t *testing.T) {
+	c, m := newTestClient(t, []mockCall{
+		// ContainerIsRunning check: returns true.
+		{wantName: "docker", wantArgs: []string{"inspect", "-f", "{{.State.Running}}", "myapp"},
+			output: "true\n", err: nil},
+		// docker stop.
+		{wantName: "docker", wantArgs: []string{"stop", "myapp"},
+			output: "myapp\n", err: nil},
+	})
+	err := c.StopContainer(context.Background(), "myapp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m.verify()
+}
+
+func TestRemoveContainerSkipsWhenNotExists(t *testing.T) {
+	c, m := newTestClient(t, []mockCall{
+		// ContainerExists check: returns false.
+		{wantName: "docker", wantArgs: []string{"inspect", "gone"},
+			output: "", err: fmt.Errorf("command \"docker\" failed: no such container")},
+	})
+	err := c.RemoveContainer(context.Background(), "gone")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m.verify()
+}
+
+func TestRemoveContainerCallsDockerRm(t *testing.T) {
+	c, m := newTestClient(t, []mockCall{
+		// ContainerExists check: returns true.
+		{wantName: "docker", wantArgs: []string{"inspect", "myapp"},
+			output: "{}", err: nil},
+		// docker rm.
+		{wantName: "docker", wantArgs: []string{"rm", "myapp"},
+			output: "myapp\n", err: nil},
+	})
+	err := c.RemoveContainer(context.Background(), "myapp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m.verify()
+}
+
+func TestStopAndRemoveCallsStopThenRemove(t *testing.T) {
+	c, m := newTestClient(t, []mockCall{
+		// StopContainer -> ContainerIsRunning: true.
+		{wantName: "docker", output: "true\n", err: nil},
+		// StopContainer -> docker stop.
+		{wantName: "docker", output: "myapp\n", err: nil},
+		// RemoveContainer -> ContainerExists: true.
+		{wantName: "docker", output: "{}", err: nil},
+		// RemoveContainer -> docker rm.
+		{wantName: "docker", output: "myapp\n", err: nil},
+	})
+	err := c.StopAndRemove(context.Background(), "myapp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m.verify()
+}
+
+func TestStopAndRemoveSucceedsWhenContainerGone(t *testing.T) {
+	c, m := newTestClient(t, []mockCall{
+		// StopContainer -> ContainerIsRunning: inspect fails (not found).
+		{wantName: "docker", output: "", err: fmt.Errorf("command \"docker\" failed: no such container")},
+		// RemoveContainer -> ContainerExists: inspect fails (not found).
+		{wantName: "docker", output: "", err: fmt.Errorf("command \"docker\" failed: no such container")},
+	})
+	err := c.StopAndRemove(context.Background(), "gone")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m.verify()
+}
+
+func TestPullImageCallsDockerPull(t *testing.T) {
+	c, m := newTestClient(t, []mockCall{
+		{wantName: "docker", wantArgs: []string{"pull", "ollama/ollama:latest"},
+			output: "Pulling...\n", err: nil},
+	})
+	err := c.PullImage(context.Background(), "ollama/ollama", "latest")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m.verify()
+}
+
+func TestRunContainerBuildsCorrectCommand(t *testing.T) {
+	cfg := ContainerConfig{
+		Name:    "ollama",
+		Image:   "ollama/ollama",
+		Tag:     "latest",
+		Volume:  "ollama",
+		VolPath: "/root/.ollama",
+		Env:     map[string]string{"OLLAMA_HOST": "localhost"},
+		GPUs:    "all",
+		Network: "host",
+		Restart: "always",
+	}
+
+	expectedArgs := cfg.RunArgs()
+
+	c, m := newTestClient(t, []mockCall{
+		{wantName: "docker", wantArgs: expectedArgs, output: "abc123\n", err: nil},
+	})
+	err := c.RunContainer(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m.verify()
+}
+
+func TestEnsureRunningStopsRemovesRunsPolls(t *testing.T) {
+	cfg := ContainerConfig{
+		Name:  "myapp",
+		Image: "img",
+		Tag:   "v1",
+	}
+
+	c, m := newTestClient(t, []mockCall{
+		// StopAndRemove -> StopContainer -> ContainerIsRunning: not running.
+		{wantName: "docker", output: "false\n", err: nil},
+		// StopAndRemove -> RemoveContainer -> ContainerExists: not found.
+		{wantName: "docker", output: "", err: fmt.Errorf("command \"docker\" failed: no such container")},
+		// RunContainer -> docker run.
+		{wantName: "docker", output: "abc123\n", err: nil},
+		// Poll -> ContainerIsRunning: true (immediate success).
+		{wantName: "docker", output: "true\n", err: nil},
+	})
+	err := c.EnsureRunning(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m.verify()
+}
+
+func TestEnsureRunningPollsUntilRunning(t *testing.T) {
+	cfg := ContainerConfig{
+		Name:  "slow",
+		Image: "img",
+		Tag:   "v1",
+	}
+
+	// Override the default retry opts by using a context with short timeout.
+	// The client uses DefaultRetryOpts internally, but the poll loop has
+	// a retry delay. For this test, the mock returns false once then true.
+	// The actual sleep in the poll loop uses time.After, so this test will
+	// take ~10s with real delays. We accept this since the mock runner is
+	// fast and the sleep is the bottleneck.
+	//
+	// To keep the test fast, we rely on the fact that the first poll returns
+	// false and the second returns true. The delay between is 10s from
+	// DefaultRetryOpts. We use a generous context timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	c, m := newTestClient(t, []mockCall{
+		// StopAndRemove -> StopContainer -> ContainerIsRunning: not running.
+		{wantName: "docker", output: "false\n", err: nil},
+		// StopAndRemove -> RemoveContainer -> ContainerExists: not found.
+		{wantName: "docker", output: "", err: fmt.Errorf("command \"docker\" failed: no such container")},
+		// RunContainer -> docker run.
+		{wantName: "docker", output: "abc123\n", err: nil},
+		// Poll 1 -> ContainerIsRunning: false.
+		{wantName: "docker", output: "false\n", err: nil},
+		// Poll 2 -> ContainerIsRunning: true.
+		{wantName: "docker", output: "true\n", err: nil},
+	})
+	err := c.EnsureRunning(ctx, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m.verify()
+}

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -90,7 +90,7 @@ func TestContainerExistsTrue(t *testing.T) {
 func TestContainerExistsFalse(t *testing.T) {
 	c, m := newTestClient(t, []mockCall{
 		{wantName: "docker", wantArgs: []string{"inspect", "missing"},
-			output: "", err: fmt.Errorf("command \"docker\" failed: no such container")},
+			output: "Error: No such container: missing", err: fmt.Errorf("command \"docker\" failed: exit status 1")},
 	})
 	exists, err := c.ContainerExists(context.Background(), "missing")
 	if err != nil {
@@ -165,7 +165,7 @@ func TestRemoveContainerSkipsWhenNotExists(t *testing.T) {
 	c, m := newTestClient(t, []mockCall{
 		// ContainerExists check: returns false.
 		{wantName: "docker", wantArgs: []string{"inspect", "gone"},
-			output: "", err: fmt.Errorf("command \"docker\" failed: no such container")},
+			output: "Error: No such container: missing", err: fmt.Errorf("command \"docker\" failed: exit status 1")},
 	})
 	err := c.RemoveContainer(context.Background(), "gone")
 	if err != nil {
@@ -211,9 +211,9 @@ func TestStopAndRemoveCallsStopThenRemove(t *testing.T) {
 func TestStopAndRemoveSucceedsWhenContainerGone(t *testing.T) {
 	c, m := newTestClient(t, []mockCall{
 		// StopContainer -> ContainerIsRunning: inspect fails (not found).
-		{wantName: "docker", output: "", err: fmt.Errorf("command \"docker\" failed: no such container")},
+		{wantName: "docker", output: "Error: No such container: missing", err: fmt.Errorf("command \"docker\" failed: exit status 1")},
 		// RemoveContainer -> ContainerExists: inspect fails (not found).
-		{wantName: "docker", output: "", err: fmt.Errorf("command \"docker\" failed: no such container")},
+		{wantName: "docker", output: "Error: No such container: missing", err: fmt.Errorf("command \"docker\" failed: exit status 1")},
 	})
 	err := c.StopAndRemove(context.Background(), "gone")
 	if err != nil {
@@ -270,7 +270,7 @@ func TestEnsureRunningStopsRemovesRunsPolls(t *testing.T) {
 		// StopAndRemove -> StopContainer -> ContainerIsRunning: not running.
 		{wantName: "docker", output: "false\n", err: nil},
 		// StopAndRemove -> RemoveContainer -> ContainerExists: not found.
-		{wantName: "docker", output: "", err: fmt.Errorf("command \"docker\" failed: no such container")},
+		{wantName: "docker", output: "Error: No such container: missing", err: fmt.Errorf("command \"docker\" failed: exit status 1")},
 		// RunContainer -> docker run.
 		{wantName: "docker", output: "abc123\n", err: nil},
 		// Poll -> ContainerIsRunning: true (immediate success).
@@ -307,7 +307,7 @@ func TestEnsureRunningPollsUntilRunning(t *testing.T) {
 		// StopAndRemove -> StopContainer -> ContainerIsRunning: not running.
 		{wantName: "docker", output: "false\n", err: nil},
 		// StopAndRemove -> RemoveContainer -> ContainerExists: not found.
-		{wantName: "docker", output: "", err: fmt.Errorf("command \"docker\" failed: no such container")},
+		{wantName: "docker", output: "Error: No such container: missing", err: fmt.Errorf("command \"docker\" failed: exit status 1")},
 		// RunContainer -> docker run.
 		{wantName: "docker", output: "abc123\n", err: nil},
 		// Poll 1 -> ContainerIsRunning: false.

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package docker
+
+import "fmt"
+
+// ContainerConfig describes the settings for a Docker container.
+type ContainerConfig struct {
+	Name    string
+	Image   string
+	Tag     string
+	Volume  string
+	VolPath string // mount path inside container
+	Env     map[string]string
+	GPUs    string // "all" or empty
+	Network string // "host" or empty
+	Restart string // "always" or empty
+}
+
+// ImageRef returns "image:tag", falling back to "latest" if Tag is empty.
+func (c ContainerConfig) ImageRef() string {
+	tag := c.Tag
+	if tag == "" {
+		tag = "latest"
+	}
+	return c.Image + ":" + tag
+}
+
+// RunArgs builds the argument list for `docker run -d` from the config fields.
+// The returned slice does not include the "docker" binary name itself.
+func (c ContainerConfig) RunArgs() []string {
+	args := []string{"run", "-d"}
+
+	if c.Name != "" {
+		args = append(args, "--name", c.Name)
+	}
+	if c.GPUs != "" {
+		args = append(args, "--gpus", c.GPUs)
+	}
+	if c.Network != "" {
+		args = append(args, "--network", c.Network)
+	}
+	if c.Restart != "" {
+		args = append(args, "--restart", c.Restart)
+	}
+	if c.Volume != "" && c.VolPath != "" {
+		args = append(args, "--volume", fmt.Sprintf("%s:%s", c.Volume, c.VolPath))
+	}
+
+	// Sort env keys for deterministic output in tests.
+	// Use a simple insertion sort since env maps are small.
+	keys := make([]string, 0, len(c.Env))
+	for k := range c.Env {
+		keys = append(keys, k)
+	}
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
+			keys[j], keys[j-1] = keys[j-1], keys[j]
+		}
+	}
+	for _, k := range keys {
+		args = append(args, "--env", fmt.Sprintf("%s=%s", k, c.Env[k]))
+	}
+
+	args = append(args, c.ImageRef())
+	return args
+}

--- a/internal/docker/container_test.go
+++ b/internal/docker/container_test.go
@@ -1,0 +1,126 @@
+//go:build linux
+
+package docker
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRunArgsAllFields(t *testing.T) {
+	cfg := ContainerConfig{
+		Name:    "ollama",
+		Image:   "ollama/ollama",
+		Tag:     "latest",
+		Volume:  "ollama",
+		VolPath: "/root/.ollama",
+		Env:     map[string]string{"OLLAMA_HOST": "localhost"},
+		GPUs:    "all",
+		Network: "host",
+		Restart: "always",
+	}
+
+	got := cfg.RunArgs()
+	want := []string{
+		"run", "-d",
+		"--name", "ollama",
+		"--gpus", "all",
+		"--network", "host",
+		"--restart", "always",
+		"--volume", "ollama:/root/.ollama",
+		"--env", "OLLAMA_HOST=localhost",
+		"ollama/ollama:latest",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RunArgs() =\n  %v\nwant\n  %v", got, want)
+	}
+}
+
+func TestRunArgsMinimalFields(t *testing.T) {
+	cfg := ContainerConfig{
+		Name:  "myapp",
+		Image: "myimage",
+		Tag:   "v1",
+	}
+
+	got := cfg.RunArgs()
+	want := []string{
+		"run", "-d",
+		"--name", "myapp",
+		"myimage:v1",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RunArgs() =\n  %v\nwant\n  %v", got, want)
+	}
+}
+
+func TestRunArgsMultipleEnvVars(t *testing.T) {
+	cfg := ContainerConfig{
+		Name:  "webui",
+		Image: "ghcr.io/open-webui/open-webui",
+		Tag:   "latest",
+		Env: map[string]string{
+			"PORT":            "3000",
+			"OLLAMA_BASE_URL": "http://localhost:11434",
+		},
+	}
+
+	got := cfg.RunArgs()
+	want := []string{
+		"run", "-d",
+		"--name", "webui",
+		"--env", "OLLAMA_BASE_URL=http://localhost:11434",
+		"--env", "PORT=3000",
+		"ghcr.io/open-webui/open-webui:latest",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RunArgs() =\n  %v\nwant\n  %v", got, want)
+	}
+}
+
+func TestImageRefDefaultTag(t *testing.T) {
+	cfg := ContainerConfig{Image: "myimage"}
+	got := cfg.ImageRef()
+	if got != "myimage:latest" {
+		t.Errorf("ImageRef() = %q, want %q", got, "myimage:latest")
+	}
+}
+
+func TestImageRefExplicitTag(t *testing.T) {
+	cfg := ContainerConfig{Image: "myimage", Tag: "v2"}
+	got := cfg.ImageRef()
+	if got != "myimage:v2" {
+		t.Errorf("ImageRef() = %q, want %q", got, "myimage:v2")
+	}
+}
+
+func TestRunArgsVolumeRequiresBothFields(t *testing.T) {
+	// Volume set but VolPath empty: no --volume arg.
+	cfg := ContainerConfig{
+		Name:   "test",
+		Image:  "img",
+		Tag:    "v1",
+		Volume: "vol",
+	}
+	for _, arg := range cfg.RunArgs() {
+		if arg == "--volume" {
+			t.Error("RunArgs() should not include --volume when VolPath is empty")
+		}
+	}
+
+	// VolPath set but Volume empty: no --volume arg.
+	cfg2 := ContainerConfig{
+		Name:    "test",
+		Image:   "img",
+		Tag:     "v1",
+		VolPath: "/data",
+	}
+	for _, arg := range cfg2.RunArgs() {
+		if arg == "--volume" {
+			t.Error("RunArgs() should not include --volume when Volume is empty")
+		}
+	}
+}

--- a/internal/docker/health.go
+++ b/internal/docker/health.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package docker
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+)
+
+// CheckHTTP runs a single HTTP health check using curl via the runner.
+// It succeeds if curl exits 0, meaning the endpoint returned HTTP 2xx.
+func (c *Client) CheckHTTP(ctx context.Context, host string, port int, path string) error {
+	url := fmt.Sprintf("http://%s:%d%s", host, port, path)
+	_, err := c.Runner.Run(ctx, "curl", "-sf", url)
+	return err
+}
+
+// WaitForHTTP retries CheckHTTP with Fibonacci backoff until it succeeds
+// or the retry attempts are exhausted.
+func (c *Client) WaitForHTTP(ctx context.Context, host string, port int, path string, opts exec.RetryOpts) error {
+	if opts.MaxAttempts < 1 {
+		return fmt.Errorf("MaxAttempts must be >= 1, got %d", opts.MaxAttempts)
+	}
+
+	url := fmt.Sprintf("http://%s:%d%s", host, port, path)
+	c.Logger.Info("waiting for %s (max %d attempts)", url, opts.MaxAttempts)
+
+	a := opts.InitialA
+	b := opts.InitialB
+
+	var lastErr error
+	for attempt := 1; attempt <= opts.MaxAttempts; attempt++ {
+		lastErr = c.CheckHTTP(ctx, host, port, path)
+		if lastErr == nil {
+			c.Logger.Info("health check passed: %s", url)
+			return nil
+		}
+
+		if attempt == opts.MaxAttempts {
+			break
+		}
+
+		var delay time.Duration
+		delay, a, b = exec.NextDelay(a, b)
+		c.Logger.Warn("health check %s failed, retry %d/%d in %s: %s",
+			url, attempt, opts.MaxAttempts, delay, lastErr)
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled waiting for %s: %w", url, ctx.Err())
+		case <-time.After(delay):
+		}
+	}
+
+	return fmt.Errorf("health check %s failed after %d attempts: %w", url, opts.MaxAttempts, lastErr)
+}

--- a/internal/docker/health_test.go
+++ b/internal/docker/health_test.go
@@ -1,0 +1,113 @@
+//go:build linux
+
+package docker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+func newHealthClient(t *testing.T, calls []mockCall) (*Client, *mockRunner) {
+	t.Helper()
+	var buf bytes.Buffer
+	logger, err := logging.NewLoggerWithWriter(&buf, "", logging.Debug2)
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+	mr := &mockRunner{calls: calls, t: t}
+	return NewClient(mr, logger), mr
+}
+
+func TestCheckHTTPSucceeds(t *testing.T) {
+	c, m := newHealthClient(t, []mockCall{
+		{wantName: "curl", wantArgs: []string{"-sf", "http://localhost:3000/"},
+			output: "", err: nil},
+	})
+	err := c.CheckHTTP(context.Background(), "localhost", 3000, "/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m.verify()
+}
+
+func TestCheckHTTPFails(t *testing.T) {
+	c, m := newHealthClient(t, []mockCall{
+		{wantName: "curl", wantArgs: []string{"-sf", "http://localhost:3000/health"},
+			output: "", err: fmt.Errorf("command \"curl\" failed: exit status 22")},
+	})
+	err := c.CheckHTTP(context.Background(), "localhost", 3000, "/health")
+	if err == nil {
+		t.Fatal("expected error for failed curl")
+	}
+	m.verify()
+}
+
+func TestWaitForHTTPRetriesUntilSuccess(t *testing.T) {
+	c, m := newHealthClient(t, []mockCall{
+		// First attempt: fail.
+		{wantName: "curl", output: "", err: fmt.Errorf("command \"curl\" failed: connection refused")},
+		// Second attempt: succeed.
+		{wantName: "curl", output: "", err: nil},
+	})
+
+	opts := exec.RetryOpts{
+		MaxAttempts: 3,
+		InitialA:    time.Millisecond,
+		InitialB:    time.Millisecond,
+	}
+	err := c.WaitForHTTP(context.Background(), "localhost", 3000, "/", opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m.verify()
+}
+
+func TestWaitForHTTPFailsAfterMaxAttempts(t *testing.T) {
+	c, m := newHealthClient(t, []mockCall{
+		{wantName: "curl", output: "", err: fmt.Errorf("command \"curl\" failed: connection refused")},
+		{wantName: "curl", output: "", err: fmt.Errorf("command \"curl\" failed: connection refused")},
+		{wantName: "curl", output: "", err: fmt.Errorf("command \"curl\" failed: connection refused")},
+	})
+
+	opts := exec.RetryOpts{
+		MaxAttempts: 3,
+		InitialA:    time.Millisecond,
+		InitialB:    time.Millisecond,
+	}
+	err := c.WaitForHTTP(context.Background(), "localhost", 3000, "/", opts)
+	if err == nil {
+		t.Fatal("expected error after max attempts")
+	}
+	if !contains(err.Error(), "after 3 attempts") {
+		t.Errorf("error = %q, want it to contain 'after 3 attempts'", err.Error())
+	}
+	m.verify()
+}
+
+func TestWaitForHTTPInvalidMaxAttempts(t *testing.T) {
+	c, _ := newHealthClient(t, nil)
+	opts := exec.RetryOpts{MaxAttempts: 0}
+	err := c.WaitForHTTP(context.Background(), "localhost", 3000, "/", opts)
+	if err == nil {
+		t.Fatal("expected error for MaxAttempts=0")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchSubstring(s, substr)
+}
+
+func searchSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/exec/allowlist.go
+++ b/internal/exec/allowlist.go
@@ -4,6 +4,13 @@ package exec
 var defaultAllowedBins = map[string]bool{
 	"docker":         true,
 	"apt-get":        true,
+	"dpkg":           true,
+	"sh":             true,
+	"install":        true,
+	"chmod":          true,
+	"usermod":        true,
+	"systemctl":      true,
+	"nvidia-ctk":     true,
 	"wsl.exe":        true,
 	"netsh":          true,
 	"powershell.exe": true,

--- a/internal/exec/allowlist.go
+++ b/internal/exec/allowlist.go
@@ -18,6 +18,9 @@ var defaultAllowedBins = map[string]bool{
 	"curl":           true,
 	"lsof":           true,
 	"nvidia-smi":     true,
+	"cat":            true,
+	"ip":             true,
+	"ping":           true,
 }
 
 // allowedBins returns the runner's AllowedBins if set, otherwise the default.

--- a/internal/nvidia/toolkit.go
+++ b/internal/nvidia/toolkit.go
@@ -1,0 +1,116 @@
+//go:build linux
+
+package nvidia
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+const (
+	gpgKeyURL  = "https://nvidia.github.io/libnvidia-container/gpgkey"
+	repoListURL = "https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list"
+	keyringPath = "/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+	repoFile    = "/etc/apt/sources.list.d/nvidia-container-toolkit.list"
+)
+
+// Installer manages NVIDIA Container Toolkit installation and verification.
+type Installer struct {
+	Runner exec.Runner
+	Logger *logging.Logger
+}
+
+// NewInstaller creates an Installer with the given runner and logger.
+func NewInstaller(runner exec.Runner, logger *logging.Logger) *Installer {
+	return &Installer{Runner: runner, Logger: logger}
+}
+
+// Install installs the NVIDIA Container Toolkit if it is not already present.
+// It checks dpkg for an existing installation, and if missing, downloads the
+// GPG key, adds the apt repository, updates package lists, and installs.
+func (i *Installer) Install(ctx context.Context) error {
+	installed, err := i.isInstalled(ctx)
+	if err != nil {
+		return fmt.Errorf("check nvidia-container-toolkit: %w", err)
+	}
+	if installed {
+		i.Logger.Info("nvidia-container-toolkit is already installed, skipping")
+		return nil
+	}
+
+	i.Logger.Info("installing NVIDIA Container Toolkit")
+
+	// Download GPG key.
+	gpgKey, err := i.Runner.Run(ctx, "curl", "-fsSL", gpgKeyURL)
+	if err != nil {
+		return fmt.Errorf("download GPG key: %w", err)
+	}
+
+	// Dearmor and write the keyring. We pass the key via stdin by writing
+	// it to a temp approach. Since we cannot pipe, we use sh -c.
+	// Actually, the runner doesn't support stdin. Write key to a temp file
+	// approach would need filesystem access. Instead, use sh -c for the
+	// gpg dearmor step.
+	_, err = i.Runner.Run(ctx, "sh", "-c",
+		fmt.Sprintf("echo '%s' | gpg --dearmor --yes -o %s", gpgKey, keyringPath))
+	if err != nil {
+		return fmt.Errorf("dearmor GPG key: %w", err)
+	}
+
+	// Download and configure the apt repository list.
+	repoList, err := i.Runner.Run(ctx, "curl", "-s", "-L", repoListURL)
+	if err != nil {
+		return fmt.Errorf("download repo list: %w", err)
+	}
+
+	// Add signed-by to the repo entries and write to the sources list.
+	signedRepo := strings.ReplaceAll(repoList, "deb https://",
+		fmt.Sprintf("deb [signed-by=%s] https://", keyringPath))
+	_, err = i.Runner.Run(ctx, "sh", "-c",
+		fmt.Sprintf("echo '%s' > %s", signedRepo, repoFile))
+	if err != nil {
+		return fmt.Errorf("write repo list: %w", err)
+	}
+
+	// Update package lists.
+	_, err = i.Runner.RunWithRetry(ctx, exec.DefaultRetryOpts(), "apt-get", "update")
+	if err != nil {
+		return fmt.Errorf("apt-get update: %w", err)
+	}
+
+	// Install the toolkit.
+	_, err = i.Runner.RunWithRetry(ctx, exec.DefaultRetryOpts(),
+		"apt-get", "install", "-y", "nvidia-container-toolkit")
+	if err != nil {
+		return fmt.Errorf("apt-get install: %w", err)
+	}
+
+	i.Logger.Info("NVIDIA Container Toolkit installed")
+	return nil
+}
+
+// Verify runs nvidia-smi to confirm GPU access.
+func (i *Installer) Verify(ctx context.Context) error {
+	i.Logger.Info("verifying GPU access via nvidia-smi")
+	_, err := i.Runner.Run(ctx, "nvidia-smi")
+	if err != nil {
+		return fmt.Errorf("nvidia-smi failed: %w", err)
+	}
+	i.Logger.Info("GPU access verified")
+	return nil
+}
+
+// isInstalled checks whether nvidia-container-toolkit is installed via dpkg.
+func (i *Installer) isInstalled(ctx context.Context) (bool, error) {
+	out, err := i.Runner.Run(ctx, "dpkg", "-l", "nvidia-container-toolkit")
+	if err != nil {
+		// dpkg -l exits non-zero when the package is not installed.
+		return false, nil //nolint:nilerr // expected: dpkg exits 1 for missing packages
+	}
+	// A line starting with "ii" means the package is installed.
+	return strings.Contains(out, "ii  nvidia-container-toolkit"), nil
+}

--- a/internal/nvidia/toolkit.go
+++ b/internal/nvidia/toolkit.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	gpgKeyURL  = "https://nvidia.github.io/libnvidia-container/gpgkey"
+	gpgKeyURL   = "https://nvidia.github.io/libnvidia-container/gpgkey"
 	repoListURL = "https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list"
 	keyringPath = "/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
 	repoFile    = "/etc/apt/sources.list.d/nvidia-container-toolkit.list"

--- a/internal/nvidia/toolkit.go
+++ b/internal/nvidia/toolkit.go
@@ -44,34 +44,19 @@ func (i *Installer) Install(ctx context.Context) error {
 
 	i.Logger.Info("installing NVIDIA Container Toolkit")
 
-	// Download GPG key.
-	gpgKey, err := i.Runner.Run(ctx, "curl", "-fsSL", gpgKeyURL)
-	if err != nil {
-		return fmt.Errorf("download GPG key: %w", err)
-	}
-
-	// Dearmor and write the keyring. We pass the key via stdin by writing
-	// it to a temp approach. Since we cannot pipe, we use sh -c.
-	// Actually, the runner doesn't support stdin. Write key to a temp file
-	// approach would need filesystem access. Instead, use sh -c for the
-	// gpg dearmor step.
+	// Download GPG key and dearmor it in a single pipeline.
+	// Avoids interpolating remote content into a shell command string.
 	_, err = i.Runner.Run(ctx, "sh", "-c",
-		fmt.Sprintf("echo '%s' | gpg --dearmor --yes -o %s", gpgKey, keyringPath))
+		fmt.Sprintf("curl -fsSL %s | gpg --dearmor --yes -o %s", gpgKeyURL, keyringPath))
 	if err != nil {
-		return fmt.Errorf("dearmor GPG key: %w", err)
+		return fmt.Errorf("download and dearmor GPG key: %w", err)
 	}
 
-	// Download and configure the apt repository list.
-	repoList, err := i.Runner.Run(ctx, "curl", "-s", "-L", repoListURL)
-	if err != nil {
-		return fmt.Errorf("download repo list: %w", err)
-	}
-
-	// Add signed-by to the repo entries and write to the sources list.
-	signedRepo := strings.ReplaceAll(repoList, "deb https://",
-		fmt.Sprintf("deb [signed-by=%s] https://", keyringPath))
+	// Download repo list, add signed-by directive, and write to sources.
+	// All done in a single pipeline to avoid interpolating remote content.
 	_, err = i.Runner.Run(ctx, "sh", "-c",
-		fmt.Sprintf("echo '%s' > %s", signedRepo, repoFile))
+		fmt.Sprintf("curl -s -L %s | sed 's#deb https://#deb [signed-by=%s] https://#g' > %s",
+			repoListURL, keyringPath, repoFile))
 	if err != nil {
 		return fmt.Errorf("write repo list: %w", err)
 	}

--- a/internal/nvidia/toolkit_test.go
+++ b/internal/nvidia/toolkit_test.go
@@ -1,0 +1,207 @@
+//go:build linux
+
+package nvidia
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+// mockCall records a single Runner invocation.
+type mockCall struct {
+	Name string
+	Args []string
+}
+
+// mockRunner records calls and returns preconfigured responses.
+type mockRunner struct {
+	calls    []mockCall
+	outputs  map[string]string // key = "name arg1 arg2 ..."
+	errors   map[string]error
+}
+
+func newMockRunner() *mockRunner {
+	return &mockRunner{
+		outputs: make(map[string]string),
+		errors:  make(map[string]error),
+	}
+}
+
+func (m *mockRunner) key(name string, args ...string) string {
+	parts := append([]string{name}, args...)
+	return strings.Join(parts, " ")
+}
+
+func (m *mockRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	m.calls = append(m.calls, mockCall{Name: name, Args: args})
+	k := m.key(name, args...)
+	if err, ok := m.errors[k]; ok {
+		return m.outputs[k], err
+	}
+	return m.outputs[k], nil
+}
+
+func (m *mockRunner) RunWithRetry(ctx context.Context, _ exec.RetryOpts, name string, args ...string) (string, error) {
+	return m.Run(ctx, name, args...)
+}
+
+func (m *mockRunner) called(name string, args ...string) bool {
+	k := m.key(name, args...)
+	for _, c := range m.calls {
+		ck := m.key(c.Name, c.Args...)
+		if ck == k {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *mockRunner) callCount() int {
+	return len(m.calls)
+}
+
+func newTestLogger(t *testing.T) *logging.Logger {
+	t.Helper()
+	var buf bytes.Buffer
+	l, err := logging.NewLoggerWithWriter(&buf, "", logging.Debug2)
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+	return l
+}
+
+func TestInstallSkipsWhenAlreadyInstalled(t *testing.T) {
+	m := newMockRunner()
+	m.outputs[m.key("dpkg", "-l", "nvidia-container-toolkit")] =
+		"ii  nvidia-container-toolkit  1.14.0  amd64  NVIDIA Container Toolkit"
+
+	inst := NewInstaller(m, newTestLogger(t))
+	err := inst.Install(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should only have called dpkg, nothing else.
+	if m.callCount() != 1 {
+		t.Errorf("expected 1 call (dpkg check), got %d: %+v", m.callCount(), m.calls)
+	}
+}
+
+func TestInstallRunsFullSequenceWhenMissing(t *testing.T) {
+	m := newMockRunner()
+	// dpkg check fails (package not installed).
+	m.errors[m.key("dpkg", "-l", "nvidia-container-toolkit")] =
+		fmt.Errorf("dpkg-query: no packages found")
+	m.outputs[m.key("curl", "-fsSL", gpgKeyURL)] = "FAKE-GPG-KEY"
+	m.outputs[m.key("curl", "-s", "-L", repoListURL)] = "deb https://nvidia.github.io/libnvidia-container/stable/deb amd64/"
+
+	inst := NewInstaller(m, newTestLogger(t))
+	err := inst.Install(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify full install sequence: dpkg, curl gpg, sh gpg, curl repo, sh repo, apt-get update, apt-get install.
+	if m.callCount() < 6 {
+		t.Errorf("expected at least 6 calls, got %d: %+v", m.callCount(), m.calls)
+	}
+
+	if !m.called("apt-get", "install", "-y", "nvidia-container-toolkit") {
+		t.Error("expected apt-get install call")
+	}
+}
+
+func TestInstallGPGKeyUsesCorrectURL(t *testing.T) {
+	m := newMockRunner()
+	m.errors[m.key("dpkg", "-l", "nvidia-container-toolkit")] =
+		fmt.Errorf("not installed")
+	m.outputs[m.key("curl", "-fsSL", gpgKeyURL)] = "KEY"
+	m.outputs[m.key("curl", "-s", "-L", repoListURL)] = "deb https://example.com/ amd64/"
+
+	inst := NewInstaller(m, newTestLogger(t))
+	_ = inst.Install(context.Background())
+
+	if !m.called("curl", "-fsSL", gpgKeyURL) {
+		t.Errorf("expected curl call with GPG key URL %s", gpgKeyURL)
+	}
+}
+
+func TestInstallAddsCorrectAptRepository(t *testing.T) {
+	m := newMockRunner()
+	m.errors[m.key("dpkg", "-l", "nvidia-container-toolkit")] =
+		fmt.Errorf("not installed")
+	m.outputs[m.key("curl", "-fsSL", gpgKeyURL)] = "KEY"
+	m.outputs[m.key("curl", "-s", "-L", repoListURL)] =
+		"deb https://nvidia.github.io/libnvidia-container/stable/deb amd64/"
+
+	inst := NewInstaller(m, newTestLogger(t))
+	_ = inst.Install(context.Background())
+
+	if !m.called("curl", "-s", "-L", repoListURL) {
+		t.Errorf("expected curl call with repo list URL %s", repoListURL)
+	}
+
+	// The sh -c call should contain signed-by.
+	found := false
+	for _, c := range m.calls {
+		if c.Name == "sh" && len(c.Args) >= 2 {
+			combined := strings.Join(c.Args, " ")
+			if strings.Contains(combined, "signed-by=") &&
+				strings.Contains(combined, repoFile) {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("expected sh -c call that writes signed-by repo to sources list")
+	}
+}
+
+func TestVerifySucceeds(t *testing.T) {
+	m := newMockRunner()
+	m.outputs[m.key("nvidia-smi")] = "GPU 0: Tesla T4"
+
+	inst := NewInstaller(m, newTestLogger(t))
+	err := inst.Verify(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVerifyFailsOnNvidiaSmiError(t *testing.T) {
+	m := newMockRunner()
+	m.errors[m.key("nvidia-smi")] = fmt.Errorf("command failed: exit 1")
+
+	inst := NewInstaller(m, newTestLogger(t))
+	err := inst.Verify(context.Background())
+	if err == nil {
+		t.Fatal("expected error when nvidia-smi fails")
+	}
+	if !strings.Contains(err.Error(), "nvidia-smi failed") {
+		t.Errorf("error = %q, want it to contain 'nvidia-smi failed'", err.Error())
+	}
+}
+
+func TestInstallAptGetUpdateFailure(t *testing.T) {
+	m := newMockRunner()
+	m.errors[m.key("dpkg", "-l", "nvidia-container-toolkit")] =
+		fmt.Errorf("not installed")
+	m.outputs[m.key("curl", "-fsSL", gpgKeyURL)] = "KEY"
+	m.outputs[m.key("curl", "-s", "-L", repoListURL)] = "deb https://example.com/ amd64/"
+	m.errors[m.key("apt-get", "update")] = fmt.Errorf("apt-get update failed")
+
+	inst := NewInstaller(m, newTestLogger(t))
+	err := inst.Install(context.Background())
+	if err == nil {
+		t.Fatal("expected error when apt-get update fails")
+	}
+	if !strings.Contains(err.Error(), "apt-get update") {
+		t.Errorf("error = %q, want it to contain 'apt-get update'", err.Error())
+	}
+}

--- a/internal/nvidia/toolkit_test.go
+++ b/internal/nvidia/toolkit_test.go
@@ -21,9 +21,9 @@ type mockCall struct {
 
 // mockRunner records calls and returns preconfigured responses.
 type mockRunner struct {
-	calls    []mockCall
-	outputs  map[string]string // key = "name arg1 arg2 ..."
-	errors   map[string]error
+	calls   []mockCall
+	outputs map[string]string // key = "name arg1 arg2 ..."
+	errors  map[string]error
 }
 
 func newMockRunner() *mockRunner {

--- a/internal/nvidia/toolkit_test.go
+++ b/internal/nvidia/toolkit_test.go
@@ -98,8 +98,6 @@ func TestInstallRunsFullSequenceWhenMissing(t *testing.T) {
 	// dpkg check fails (package not installed).
 	m.errors[m.key("dpkg", "-l", "nvidia-container-toolkit")] =
 		fmt.Errorf("dpkg-query: no packages found")
-	m.outputs[m.key("curl", "-fsSL", gpgKeyURL)] = "FAKE-GPG-KEY"
-	m.outputs[m.key("curl", "-s", "-L", repoListURL)] = "deb https://nvidia.github.io/libnvidia-container/stable/deb amd64/"
 
 	inst := NewInstaller(m, newTestLogger(t))
 	err := inst.Install(context.Background())
@@ -107,9 +105,10 @@ func TestInstallRunsFullSequenceWhenMissing(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify full install sequence: dpkg, curl gpg, sh gpg, curl repo, sh repo, apt-get update, apt-get install.
-	if m.callCount() < 6 {
-		t.Errorf("expected at least 6 calls, got %d: %+v", m.callCount(), m.calls)
+	// Verify full install sequence: dpkg, sh (gpg pipeline), sh (repo pipeline),
+	// apt-get update, apt-get install.
+	if m.callCount() < 5 {
+		t.Errorf("expected at least 5 calls, got %d: %+v", m.callCount(), m.calls)
 	}
 
 	if !m.called("apt-get", "install", "-y", "nvidia-container-toolkit") {
@@ -121,14 +120,21 @@ func TestInstallGPGKeyUsesCorrectURL(t *testing.T) {
 	m := newMockRunner()
 	m.errors[m.key("dpkg", "-l", "nvidia-container-toolkit")] =
 		fmt.Errorf("not installed")
-	m.outputs[m.key("curl", "-fsSL", gpgKeyURL)] = "KEY"
-	m.outputs[m.key("curl", "-s", "-L", repoListURL)] = "deb https://example.com/ amd64/"
 
 	inst := NewInstaller(m, newTestLogger(t))
 	_ = inst.Install(context.Background())
 
-	if !m.called("curl", "-fsSL", gpgKeyURL) {
-		t.Errorf("expected curl call with GPG key URL %s", gpgKeyURL)
+	// The GPG key download is now a pipeline inside sh -c.
+	found := false
+	for _, c := range m.calls {
+		if c.Name == "sh" && len(c.Args) >= 2 &&
+			strings.Contains(c.Args[1], gpgKeyURL) &&
+			strings.Contains(c.Args[1], "gpg --dearmor") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected sh -c pipeline with GPG key URL %s", gpgKeyURL)
 	}
 }
 
@@ -136,30 +142,22 @@ func TestInstallAddsCorrectAptRepository(t *testing.T) {
 	m := newMockRunner()
 	m.errors[m.key("dpkg", "-l", "nvidia-container-toolkit")] =
 		fmt.Errorf("not installed")
-	m.outputs[m.key("curl", "-fsSL", gpgKeyURL)] = "KEY"
-	m.outputs[m.key("curl", "-s", "-L", repoListURL)] =
-		"deb https://nvidia.github.io/libnvidia-container/stable/deb amd64/"
 
 	inst := NewInstaller(m, newTestLogger(t))
 	_ = inst.Install(context.Background())
 
-	if !m.called("curl", "-s", "-L", repoListURL) {
-		t.Errorf("expected curl call with repo list URL %s", repoListURL)
-	}
-
-	// The sh -c call should contain signed-by.
+	// The repo setup is now a pipeline: curl | sed > file.
 	found := false
 	for _, c := range m.calls {
-		if c.Name == "sh" && len(c.Args) >= 2 {
-			combined := strings.Join(c.Args, " ")
-			if strings.Contains(combined, "signed-by=") &&
-				strings.Contains(combined, repoFile) {
-				found = true
-			}
+		if c.Name == "sh" && len(c.Args) >= 2 &&
+			strings.Contains(c.Args[1], repoListURL) &&
+			strings.Contains(c.Args[1], "signed-by=") &&
+			strings.Contains(c.Args[1], repoFile) {
+			found = true
 		}
 	}
 	if !found {
-		t.Error("expected sh -c call that writes signed-by repo to sources list")
+		t.Error("expected sh -c pipeline that writes signed-by repo to sources list")
 	}
 }
 
@@ -192,8 +190,6 @@ func TestInstallAptGetUpdateFailure(t *testing.T) {
 	m := newMockRunner()
 	m.errors[m.key("dpkg", "-l", "nvidia-container-toolkit")] =
 		fmt.Errorf("not installed")
-	m.outputs[m.key("curl", "-fsSL", gpgKeyURL)] = "KEY"
-	m.outputs[m.key("curl", "-s", "-L", repoListURL)] = "deb https://example.com/ amd64/"
 	m.errors[m.key("apt-get", "update")] = fmt.Errorf("apt-get update failed")
 
 	inst := NewInstaller(m, newTestLogger(t))

--- a/internal/ollama/install.go
+++ b/internal/ollama/install.go
@@ -1,0 +1,79 @@
+//go:build linux
+
+package ollama
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+const installScriptURL = "https://ollama.com/install.sh"
+
+// Manager handles Ollama installation and model management.
+type Manager struct {
+	Runner exec.Runner
+	Logger *logging.Logger
+}
+
+// NewManager creates a Manager with the given runner and logger.
+func NewManager(runner exec.Runner, logger *logging.Logger) *Manager {
+	return &Manager{Runner: runner, Logger: logger}
+}
+
+// IsInstalled returns true if the ollama binary is available.
+func (m *Manager) IsInstalled(ctx context.Context) (bool, error) {
+	_, err := m.Runner.Run(ctx, "ollama", "--version")
+	if err != nil {
+		return false, nil //nolint:nilerr // expected: ollama not found
+	}
+	return true, nil
+}
+
+// Install checks for an existing ollama installation. If missing, it downloads
+// the official install script via curl and executes it with sh.
+func (m *Manager) Install(ctx context.Context) error {
+	installed, err := m.IsInstalled(ctx)
+	if err != nil {
+		return fmt.Errorf("check ollama: %w", err)
+	}
+	if installed {
+		m.Logger.Info("ollama is already installed, skipping")
+		return nil
+	}
+
+	m.Logger.Info("installing ollama via official install script")
+
+	// Download the install script to a temp file.
+	tmpFile, err := os.CreateTemp("", "ollama-install-*.sh")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name()) //nolint:errcheck // best-effort cleanup
+	tmpFile.Close()                 //nolint:errcheck,gosec // closed before use by curl
+
+	_, err = m.Runner.Run(ctx, "curl", "-fsSL", "-o", tmpFile.Name(), installScriptURL)
+	if err != nil {
+		return fmt.Errorf("download install script: %w", err)
+	}
+
+	_, err = m.Runner.Run(ctx, "sh", tmpFile.Name())
+	if err != nil {
+		return fmt.Errorf("run install script: %w", err)
+	}
+
+	// Verify installation succeeded.
+	installed, err = m.IsInstalled(ctx)
+	if err != nil {
+		return fmt.Errorf("verify ollama post-install: %w", err)
+	}
+	if !installed {
+		return fmt.Errorf("ollama installation completed but binary not found")
+	}
+
+	m.Logger.Info("ollama installed")
+	return nil
+}

--- a/internal/ollama/install_test.go
+++ b/internal/ollama/install_test.go
@@ -124,7 +124,7 @@ func TestInstallRunsCurlAndShWhenMissing(t *testing.T) {
 	// We need --version to fail first time, succeed second time.
 	// Replace the mock with a stateful one.
 	sm := &statefulMockRunner{
-		mockRunner:    m,
+		mockRunner:   m,
 		versionCalls: 0,
 	}
 	mgr.Runner = sm
@@ -154,10 +154,10 @@ func (s *statefulMockRunner) Run(ctx context.Context, name string, args ...strin
 	if name == "ollama" && len(args) > 0 && args[0] == "--version" {
 		s.versionCalls++
 		if s.versionCalls == 1 {
-			s.mockRunner.calls = append(s.mockRunner.calls, mockCall{Name: name, Args: args})
+			s.calls = append(s.calls, mockCall{Name: name, Args: args})
 			return "", fmt.Errorf("not found")
 		}
-		s.mockRunner.calls = append(s.mockRunner.calls, mockCall{Name: name, Args: args})
+		s.calls = append(s.calls, mockCall{Name: name, Args: args})
 		return "ollama version 0.1.0", nil
 	}
 	return s.mockRunner.Run(ctx, name, args...)

--- a/internal/ollama/install_test.go
+++ b/internal/ollama/install_test.go
@@ -1,0 +1,196 @@
+//go:build linux
+
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+// mockCall records a single Runner invocation.
+type mockCall struct {
+	Name string
+	Args []string
+}
+
+// mockRunner records calls and returns preconfigured responses.
+type mockRunner struct {
+	calls   []mockCall
+	outputs map[string]string
+	errors  map[string]error
+}
+
+func newMockRunner() *mockRunner {
+	return &mockRunner{
+		outputs: make(map[string]string),
+		errors:  make(map[string]error),
+	}
+}
+
+func (m *mockRunner) key(name string, args ...string) string {
+	parts := append([]string{name}, args...)
+	return strings.Join(parts, " ")
+}
+
+func (m *mockRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	m.calls = append(m.calls, mockCall{Name: name, Args: args})
+	k := m.key(name, args...)
+	if err, ok := m.errors[k]; ok {
+		return m.outputs[k], err
+	}
+	return m.outputs[k], nil
+}
+
+func (m *mockRunner) RunWithRetry(ctx context.Context, _ exec.RetryOpts, name string, args ...string) (string, error) {
+	return m.Run(ctx, name, args...)
+}
+
+func (m *mockRunner) called(name string, args ...string) bool {
+	k := m.key(name, args...)
+	for _, c := range m.calls {
+		ck := m.key(c.Name, c.Args...)
+		if ck == k {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *mockRunner) callCount() int {
+	return len(m.calls)
+}
+
+// calledPrefix returns true if any call starts with the given name and args.
+func (m *mockRunner) calledPrefix(name string, args ...string) bool {
+	for _, c := range m.calls {
+		if c.Name != name {
+			continue
+		}
+		if len(c.Args) < len(args) {
+			continue
+		}
+		match := true
+		for i, a := range args {
+			if c.Args[i] != a {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func newTestLogger(t *testing.T) *logging.Logger {
+	t.Helper()
+	var buf bytes.Buffer
+	l, err := logging.NewLoggerWithWriter(&buf, "", logging.Debug2)
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+	return l
+}
+
+func TestInstallSkipsWhenAlreadyInstalled(t *testing.T) {
+	m := newMockRunner()
+	m.outputs[m.key("ollama", "--version")] = "ollama version 0.1.0"
+
+	mgr := NewManager(m, newTestLogger(t))
+	err := mgr.Install(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only the version check should be called.
+	if m.callCount() != 1 {
+		t.Errorf("expected 1 call, got %d: %+v", m.callCount(), m.calls)
+	}
+}
+
+func TestInstallRunsCurlAndShWhenMissing(t *testing.T) {
+	m := newMockRunner()
+	m.errors[m.key("ollama", "--version")] = fmt.Errorf("not found")
+
+	mgr := NewManager(m, newTestLogger(t))
+
+	// We need --version to fail first time, succeed second time.
+	// Replace the mock with a stateful one.
+	sm := &statefulMockRunner{
+		mockRunner:    m,
+		versionCalls: 0,
+	}
+	mgr.Runner = sm
+
+	err := mgr.Install(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have called curl and sh.
+	if !sm.calledPrefix("curl", "-fsSL", "-o") {
+		t.Error("expected curl call to download install script")
+	}
+	if !sm.calledPrefix("sh") {
+		t.Error("expected sh call to run install script")
+	}
+}
+
+// statefulMockRunner tracks version call count so the first fails and
+// subsequent succeed.
+type statefulMockRunner struct {
+	*mockRunner
+	versionCalls int
+}
+
+func (s *statefulMockRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	if name == "ollama" && len(args) > 0 && args[0] == "--version" {
+		s.versionCalls++
+		if s.versionCalls == 1 {
+			s.mockRunner.calls = append(s.mockRunner.calls, mockCall{Name: name, Args: args})
+			return "", fmt.Errorf("not found")
+		}
+		s.mockRunner.calls = append(s.mockRunner.calls, mockCall{Name: name, Args: args})
+		return "ollama version 0.1.0", nil
+	}
+	return s.mockRunner.Run(ctx, name, args...)
+}
+
+func (s *statefulMockRunner) RunWithRetry(ctx context.Context, opts exec.RetryOpts, name string, args ...string) (string, error) {
+	return s.Run(ctx, name, args...)
+}
+
+func TestIsInstalledReturnsTrueOnSuccess(t *testing.T) {
+	m := newMockRunner()
+	m.outputs[m.key("ollama", "--version")] = "ollama version 0.1.0"
+
+	mgr := NewManager(m, newTestLogger(t))
+	installed, err := mgr.IsInstalled(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !installed {
+		t.Error("expected IsInstalled to return true")
+	}
+}
+
+func TestIsInstalledReturnsFalseOnFailure(t *testing.T) {
+	m := newMockRunner()
+	m.errors[m.key("ollama", "--version")] = fmt.Errorf("not found")
+
+	mgr := NewManager(m, newTestLogger(t))
+	installed, err := mgr.IsInstalled(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if installed {
+		t.Error("expected IsInstalled to return false")
+	}
+}

--- a/internal/ollama/models.go
+++ b/internal/ollama/models.go
@@ -1,0 +1,91 @@
+//go:build linux
+
+package ollama
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+)
+
+// PullModel pulls a single model via `ollama pull` with retry.
+func (m *Manager) PullModel(ctx context.Context, model string) error {
+	m.Logger.Info("pulling model: %s", model)
+	_, err := m.Runner.RunWithRetry(ctx, exec.DefaultRetryOpts(), "ollama", "pull", model)
+	if err != nil {
+		return fmt.Errorf("pull model %s: %w", model, err)
+	}
+	return nil
+}
+
+// PullModels pulls each model in the list. It skips models that are already
+// installed (present in ListModels output).
+func (m *Manager) PullModels(ctx context.Context, models []string) error {
+	if len(models) == 0 {
+		m.Logger.Info("no models to pull")
+		return nil
+	}
+
+	installed, err := m.ListModels(ctx)
+	if err != nil {
+		// If listing fails (e.g., ollama not running), proceed with pulls anyway.
+		m.Logger.Warn("could not list installed models: %v", err)
+		installed = nil
+	}
+
+	installedSet := make(map[string]bool, len(installed))
+	for _, name := range installed {
+		installedSet[name] = true
+	}
+
+	for _, model := range models {
+		if installedSet[model] {
+			m.Logger.Info("model %s already installed, skipping", model)
+			continue
+		}
+		if err := m.PullModel(ctx, model); err != nil {
+			return err
+		}
+	}
+
+	m.Logger.Info("model pulling completed")
+	return nil
+}
+
+// ListModels runs `ollama list` and parses the output to return model names.
+// The output format is a header line followed by rows where the first column
+// is the model name.
+func (m *Manager) ListModels(ctx context.Context) ([]string, error) {
+	out, err := m.Runner.Run(ctx, "ollama", "list")
+	if err != nil {
+		return nil, fmt.Errorf("ollama list: %w", err)
+	}
+	return parseModelList(out), nil
+}
+
+// RunInteractive returns the command and arguments needed to run a model
+// interactively. Actual interactive execution requires terminal wiring that
+// will be handled by the cobra command layer.
+func (m *Manager) RunInteractive(_ context.Context, model string) (string, []string) {
+	return "ollama", []string{"run", model}
+}
+
+// parseModelList extracts model names from `ollama list` output.
+// It skips the header line and extracts the first whitespace-delimited field.
+func parseModelList(output string) []string {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) <= 1 {
+		return nil
+	}
+
+	var models []string
+	for _, line := range lines[1:] { // skip header
+		fields := strings.Fields(line)
+		if len(fields) > 0 {
+			models = append(models, fields[0])
+		}
+	}
+	return models
+}

--- a/internal/ollama/models_test.go
+++ b/internal/ollama/models_test.go
@@ -1,0 +1,172 @@
+//go:build linux
+
+package ollama
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestPullModelCallsOllamaPull(t *testing.T) {
+	m := newMockRunner()
+	mgr := NewManager(m, newTestLogger(t))
+
+	err := mgr.PullModel(context.Background(), "llama3.2:1b")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !m.called("ollama", "pull", "llama3.2:1b") {
+		t.Error("expected ollama pull call with correct model name")
+	}
+}
+
+func TestPullModelUsesRetry(t *testing.T) {
+	m := newMockRunner()
+	// Verify RunWithRetry is used by checking the call goes through.
+	// The mock's RunWithRetry delegates to Run, so the call is recorded.
+	mgr := NewManager(m, newTestLogger(t))
+
+	err := mgr.PullModel(context.Background(), "mistral:latest")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !m.called("ollama", "pull", "mistral:latest") {
+		t.Error("expected ollama pull call via retry path")
+	}
+}
+
+func TestPullModelsPullsEachInOrder(t *testing.T) {
+	m := newMockRunner()
+	// ListModels returns empty so all models need pulling.
+	m.outputs[m.key("ollama", "list")] = "NAME\tID\tSIZE\tMODIFIED\n"
+
+	mgr := NewManager(m, newTestLogger(t))
+	models := []string{"llama3.2:1b", "mistral:latest", "phi3:mini"}
+	err := mgr.PullModels(context.Background(), models)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, model := range models {
+		if !m.called("ollama", "pull", model) {
+			t.Errorf("expected ollama pull %s", model)
+		}
+	}
+
+	// Verify ordering: find indices of pull calls.
+	pullIndices := make(map[string]int)
+	for i, c := range m.calls {
+		if c.Name == "ollama" && len(c.Args) >= 2 && c.Args[0] == "pull" {
+			pullIndices[c.Args[1]] = i
+		}
+	}
+	for i := 1; i < len(models); i++ {
+		prev := pullIndices[models[i-1]]
+		curr := pullIndices[models[i]]
+		if curr <= prev {
+			t.Errorf("model %s pulled before %s", models[i], models[i-1])
+		}
+	}
+}
+
+func TestPullModelsHandlesEmptyList(t *testing.T) {
+	m := newMockRunner()
+	mgr := NewManager(m, newTestLogger(t))
+
+	err := mgr.PullModels(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No calls should be made.
+	if m.callCount() != 0 {
+		t.Errorf("expected 0 calls, got %d: %+v", m.callCount(), m.calls)
+	}
+}
+
+func TestListModelsParseOutput(t *testing.T) {
+	m := newMockRunner()
+	m.outputs[m.key("ollama", "list")] = `NAME                    ID              SIZE    MODIFIED
+llama3.2:1b             abc123          1.3 GB  2 hours ago
+mistral:latest          def456          4.1 GB  1 day ago
+`
+
+	mgr := NewManager(m, newTestLogger(t))
+	models, err := mgr.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{"llama3.2:1b", "mistral:latest"}
+	if len(models) != len(expected) {
+		t.Fatalf("got %d models, want %d: %v", len(models), len(expected), models)
+	}
+	for i, e := range expected {
+		if models[i] != e {
+			t.Errorf("models[%d] = %q, want %q", i, models[i], e)
+		}
+	}
+}
+
+func TestListModelsReturnsEmptyOnNoModels(t *testing.T) {
+	m := newMockRunner()
+	m.outputs[m.key("ollama", "list")] = "NAME\tID\tSIZE\tMODIFIED\n"
+
+	mgr := NewManager(m, newTestLogger(t))
+	models, err := mgr.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(models) != 0 {
+		t.Errorf("expected empty slice, got %v", models)
+	}
+}
+
+func TestPullModelReturnsErrorOnFailure(t *testing.T) {
+	m := newMockRunner()
+	m.errors[m.key("ollama", "pull", "bad-model")] = fmt.Errorf("pull failed")
+
+	mgr := NewManager(m, newTestLogger(t))
+	err := mgr.PullModel(context.Background(), "bad-model")
+	if err == nil {
+		t.Fatal("expected error for failed pull")
+	}
+}
+
+func TestRunInteractiveReturnsCommand(t *testing.T) {
+	m := newMockRunner()
+	mgr := NewManager(m, newTestLogger(t))
+
+	cmd, args := mgr.RunInteractive(context.Background(), "llama3.2:1b")
+	if cmd != "ollama" {
+		t.Errorf("command = %q, want 'ollama'", cmd)
+	}
+	if len(args) != 2 || args[0] != "run" || args[1] != "llama3.2:1b" {
+		t.Errorf("args = %v, want [run llama3.2:1b]", args)
+	}
+}
+
+func TestPullModelsSkipsInstalledModels(t *testing.T) {
+	m := newMockRunner()
+	m.outputs[m.key("ollama", "list")] = `NAME                    ID              SIZE    MODIFIED
+llama3.2:1b             abc123          1.3 GB  2 hours ago
+`
+
+	mgr := NewManager(m, newTestLogger(t))
+	err := mgr.PullModels(context.Background(), []string{"llama3.2:1b", "mistral:latest"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// llama3.2:1b should be skipped, mistral:latest should be pulled.
+	if m.called("ollama", "pull", "llama3.2:1b") {
+		t.Error("should not pull already-installed model llama3.2:1b")
+	}
+	if !m.called("ollama", "pull", "mistral:latest") {
+		t.Error("should pull mistral:latest")
+	}
+}


### PR DESCRIPTION
## Summary

Existing Bash scripts (`update_open-webui.sh`, `repo_lib.sh`) handle the full
WSL2 setup flow but are hard to extend and test in isolation. This PR adds a Go
CLI (`ow`) that reimplements the same setup sequence, container management, and
diagnostics as the Bash scripts, designed to run side-by-side until the Go CLI
is validated on real WSL2. Bash scripts are untouched; the Go CLI is opt-in.

The side-by-side constraint shaped two key decisions. First, Go uses its own
config file (`ow.yaml`) rather than parsing the Bash config, but compiled
defaults match the Bash defaults exactly. A guardrail test parses
`update_open-webui.config.sh` and asserts parity, so CI catches drift. Second,
container config builders produce `docker run` arguments identical to the Bash
scripts (same env vars, volume mounts, restart policy, GPU flags), verified by
tests that hardcode the expected argument lists from `repo_lib.sh`.

**14 commits, 33 files, +3,556 lines across 7 internal packages and 6 CLI commands.**

### Packages

| Package | Purpose |
|---------|---------|
| `internal/docker` | Container lifecycle (exists, running, stop, remove, pull, run, health check) |
| `internal/apt` | System packages, Docker/NVIDIA keyring setup, user group management |
| `internal/nvidia` | NVIDIA Container Toolkit install and verification |
| `internal/ollama` | Ollama binary install, model pull/list, interactive run |
| `internal/exec` | Command runner with binary allowlist, Fibonacci retry |
| `internal/config` | YAML config with defaults, env var, and flag override chain |
| `internal/logging` | Leveled logger (stderr + optional file) |

### CLI commands

| Command | Replaces |
|---------|----------|
| `ow setup` | `update_open-webui.sh` (full 11-step sequence) |
| `ow containers up/down/status` | `stop_remove_run_*_container()`, `container_is_running()` |
| `ow ollama pull/run/models` | `pull_ollama_models()`, `ollama_run.sh` |
| `ow diagnose` | `diagnose_ollama.sh`, `diagnose_open-webui.sh` |
| `ow config show` | No Bash equivalent (new capability) |
| `ow version` | No Bash equivalent |

## Testing

**Unit tests (mock-based, no shell-outs):**
- All 7 internal packages have tests. Linux-tagged packages (`docker`, `apt`,
  `nvidia`, `ollama`) use mock runners. Platform-agnostic packages (`config`,
  `exec`, `logging`) run on macOS and Linux.
- `go test ./...` passes on macOS (3 packages). `go test -c ./cmd/ow/` compiles
  all linux-tagged tests.

**Parity guardrail test:**
- `defaults_parity_test.go` parses `update_open-webui.config.sh` as text and
  asserts every value matches `config.Defaults()`. Runs on all platforms.
- `containers_cmd_test.go` asserts `RunArgs()` output matches the exact `docker
  run` argument lists from `repo_lib.sh` lines 572-579 and 647-655.

**Integration tests (build-tagged `linux && integration`):**
- Build the `ow` binary, run `ow config show` and verify YAML round-trips to
  matching defaults. Verify `ow version` includes OS/arch. Verify all
  subcommands appear in help output.

**Mutation testing (gremlins, macOS-runnable packages only):**
- `config`: 92.31% (1 survivor: `os.UserHomeDir()` error path, acceptable)
- `exec`: 100%
- `logging`: 100%
- Linux-tagged packages deferred to WSL2 or CI runner.

**Cross-compilation:** `GOOS=linux GOARCH=amd64 go build ./cmd/ow/` and
`go vet ./...` pass clean.

**Not yet tested:** End-to-end `ow setup` on real WSL2. Planned for
post-merge validation before marking the PR ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)