### PR TITLE
Milestone 3: Windows CLI (ow.exe)

### DIFF
--- a/cmd/ow/diagnose_windows.go
+++ b/cmd/ow/diagnose_windows.go
@@ -1,0 +1,147 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/netsh"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/wsl"
+	"github.com/spf13/cobra"
+)
+
+var diagnoseCmd = &cobra.Command{
+	Use:   "diagnose",
+	Short: "Run diagnostic checks on WSL, Docker, port proxy, and connectivity",
+	RunE:  runDiagnose,
+}
+
+func init() {
+	rootCmd.AddCommand(diagnoseCmd)
+}
+
+func runDiagnose(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Resolve(nil)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	logger, err := logging.NewLogger("", logging.Info)
+	if err != nil {
+		return fmt.Errorf("creating logger: %w", err)
+	}
+
+	runner := &exec.RealRunner{Logger: logger}
+	ctx := cmd.Context()
+
+	wslMgr := wsl.NewManager(runner, logger)
+	netshClient := netsh.NewClient(runner, logger)
+
+	// System info.
+	fmt.Println("=== System Info ===")
+	fmt.Printf("OS: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	out, err := runner.Run(ctx, "powershell.exe", "-Command", "Get-ComputerInfo | Select-Object WindowsVersion, OsBuildNumber, CsName | Format-List")
+	if err == nil {
+		fmt.Println(strings.TrimRight(out, "\n"))
+	}
+	fmt.Println()
+
+	// WSL status.
+	fmt.Println("=== WSL Status ===")
+	installed, _ := wslMgr.IsInstalled(ctx)
+	if installed {
+		fmt.Println("WSL: installed")
+	} else {
+		fmt.Println("WSL: not installed")
+	}
+	out, err = runner.Run(ctx, "wsl.exe", "--list", "--verbose")
+	if err == nil {
+		fmt.Println(strings.TrimRight(out, "\n\x00"))
+	} else {
+		fmt.Printf("  (error: %v)\n", err)
+	}
+	fmt.Println()
+
+	// Distro check.
+	fmt.Printf("=== Distro: %s ===\n", cfg.WSL.Distro)
+	distroInstalled, _ := wslMgr.IsDistroInstalled(ctx, cfg.WSL.Distro)
+	if distroInstalled {
+		fmt.Printf("%s: installed\n", cfg.WSL.Distro)
+	} else {
+		fmt.Printf("%s: not installed\n", cfg.WSL.Distro)
+	}
+	fmt.Println()
+
+	// Port proxy rules.
+	fmt.Println("=== Port Proxy Rules ===")
+	rules, err := netshClient.ListPortProxy(ctx)
+	if err != nil {
+		fmt.Printf("  (error: %v)\n", err)
+	} else if len(rules) == 0 {
+		fmt.Println("  No rules found.")
+	} else {
+		for _, r := range rules {
+			fmt.Printf("  %s:%d -> %s:%d\n",
+				r.ListenAddress, r.ListenPort,
+				r.ConnectAddress, r.ConnectPort)
+		}
+	}
+	fmt.Println()
+
+	// Firewall rule check.
+	fmt.Println("=== Firewall Rules ===")
+	fwName := firewallRuleName(cfg)
+	fwExists, err := netshClient.FirewallRuleExists(ctx, fwName)
+	if err != nil {
+		fmt.Printf("  (error checking %s: %v)\n", fwName, err)
+	} else if fwExists {
+		fmt.Printf("  %s: exists\n", fwName)
+	} else {
+		fmt.Printf("  %s: missing\n", fwName)
+	}
+	fmt.Println()
+
+	// TCP connectivity test to OpenWebUI port.
+	fmt.Printf("=== Test OpenWebUI Port (%d) ===\n", cfg.OpenWebUI.Port)
+	out, err = runner.Run(ctx, "powershell.exe", "-Command",
+		fmt.Sprintf("Test-NetConnection -ComputerName %s -Port %d | Select-Object TcpTestSucceeded | Format-List",
+			cfg.OpenWebUI.Host, cfg.OpenWebUI.Port))
+	if err == nil {
+		fmt.Println(strings.TrimRight(out, "\n"))
+	} else {
+		fmt.Printf("  (error: %v)\n", err)
+	}
+	fmt.Println()
+
+	// TCP connectivity test to Ollama port.
+	fmt.Printf("=== Test Ollama Port (%d) ===\n", cfg.Ollama.Port)
+	out, err = runner.Run(ctx, "powershell.exe", "-Command",
+		fmt.Sprintf("Test-NetConnection -ComputerName %s -Port %d | Select-Object TcpTestSucceeded | Format-List",
+			cfg.Ollama.Host, cfg.Ollama.Port))
+	if err == nil {
+		fmt.Println(strings.TrimRight(out, "\n"))
+	} else {
+		fmt.Printf("  (error: %v)\n", err)
+	}
+	fmt.Println()
+
+	// Docker status inside WSL (if distro is installed).
+	if distroInstalled {
+		fmt.Println("=== Docker Status (WSL) ===")
+		out, err = wslMgr.RunCommand(ctx, cfg.WSL.Distro, "docker", "ps")
+		if err != nil {
+			fmt.Printf("  (error: %v)\n", err)
+		} else {
+			fmt.Println(strings.TrimRight(out, "\n"))
+		}
+		fmt.Println()
+	}
+
+	fmt.Println("=== END DIAGNOSTICS ===")
+	return nil
+}

--- a/cmd/ow/diagnose_windows_test.go
+++ b/cmd/ow/diagnose_windows_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package main
+
+import (
+	"testing"
+)
+
+func TestDiagnoseCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "diagnose" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("diagnose command not registered on rootCmd")
+	}
+}

--- a/cmd/ow/integration_windows_test.go
+++ b/cmd/ow/integration_windows_test.go
@@ -1,0 +1,100 @@
+//go:build windows && integration
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// TestConfigShowRoundTripWindows builds the binary, runs `ow config show`,
+// and verifies the YAML output unmarshals back to a config matching Defaults().
+func TestConfigShowRoundTripWindows(t *testing.T) {
+	binary := buildOWWindows(t)
+
+	out, err := exec.Command(binary, "config", "show").CombinedOutput()
+	if err != nil {
+		t.Fatalf("ow config show failed: %v\n%s", err, out)
+	}
+
+	var got config.Config
+	if err := yaml.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal config show output: %v", err)
+	}
+
+	want := config.Defaults()
+
+	if got.Ollama.Port != want.Ollama.Port {
+		t.Errorf("ollama.port: got %d, want %d", got.Ollama.Port, want.Ollama.Port)
+	}
+	if got.WSL.Distro != want.WSL.Distro {
+		t.Errorf("wsl.distro: got %q, want %q", got.WSL.Distro, want.WSL.Distro)
+	}
+	if got.Proxy.ListenAddress != want.Proxy.ListenAddress {
+		t.Errorf("proxy.listen_address: got %q, want %q",
+			got.Proxy.ListenAddress, want.Proxy.ListenAddress)
+	}
+}
+
+// TestVersionOutputWindows verifies that `ow version` runs and includes windows.
+func TestVersionOutputWindows(t *testing.T) {
+	binary := buildOWWindows(t)
+
+	out, err := exec.Command(binary, "version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("ow version failed: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "windows") {
+		t.Errorf("version output missing 'windows': %s", out)
+	}
+}
+
+// TestSubcommandTreeWindows verifies all expected Windows subcommands exist.
+func TestSubcommandTreeWindows(t *testing.T) {
+	binary := buildOWWindows(t)
+
+	tests := []struct {
+		args []string
+		want string
+	}{
+		{[]string{"help"}, "setup"},
+		{[]string{"help"}, "wsl"},
+		{[]string{"help"}, "proxy"},
+		{[]string{"help"}, "diagnose"},
+		{[]string{"help"}, "config"},
+		{[]string{"help"}, "version"},
+		{[]string{"wsl", "help"}, "install"},
+		{[]string{"wsl", "help"}, "remove"},
+		{[]string{"wsl", "help"}, "stop"},
+		{[]string{"proxy", "help"}, "enable"},
+		{[]string{"proxy", "help"}, "remove"},
+		{[]string{"proxy", "help"}, "show"},
+	}
+
+	for _, tt := range tests {
+		out, err := exec.Command(binary, tt.args...).CombinedOutput()
+		if err != nil {
+			t.Errorf("ow %s failed: %v", strings.Join(tt.args, " "), err)
+			continue
+		}
+		if !strings.Contains(string(out), tt.want) {
+			t.Errorf("ow %s output missing %q:\n%s",
+				strings.Join(tt.args, " "), tt.want, out)
+		}
+	}
+}
+
+func buildOWWindows(t *testing.T) string {
+	t.Helper()
+	binary := t.TempDir() + "\\ow.exe"
+	cmd := exec.Command("go", "build", "-o", binary, "./cmd/ow/")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return binary
+}

--- a/cmd/ow/proxy_cmd.go
+++ b/cmd/ow/proxy_cmd.go
@@ -1,0 +1,143 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/netsh"
+	"github.com/spf13/cobra"
+)
+
+var proxyCmd = &cobra.Command{
+	Use:   "proxy",
+	Short: "Manage port proxy and firewall rules",
+}
+
+var proxyEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Create port proxy and firewall rule for OpenWebUI access",
+	RunE:  runProxyEnable,
+}
+
+var proxyRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove port proxy rules",
+	RunE:  runProxyRemove,
+}
+
+var proxyShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show current port proxy rules",
+	RunE:  runProxyShow,
+}
+
+func init() {
+	rootCmd.AddCommand(proxyCmd)
+	proxyCmd.AddCommand(proxyEnableCmd)
+	proxyCmd.AddCommand(proxyRemoveCmd)
+	proxyCmd.AddCommand(proxyShowCmd)
+}
+
+func newNetshClient() (*netsh.Client, error) {
+	logger, err := logging.NewLogger("", logging.Info)
+	if err != nil {
+		return nil, fmt.Errorf("creating logger: %w", err)
+	}
+	runner := &exec.RealRunner{Logger: logger}
+	return netsh.NewClient(runner, logger), nil
+}
+
+func proxyRuleFromConfig(cfg config.Config) netsh.ProxyRule {
+	return netsh.ProxyRule{
+		ListenAddress:  cfg.Proxy.ListenAddress,
+		ListenPort:     cfg.Proxy.ListenPort,
+		ConnectAddress: cfg.Proxy.ConnectAddress,
+		ConnectPort:    cfg.Proxy.ConnectPort,
+	}
+}
+
+func firewallRuleName(cfg config.Config) string {
+	return fmt.Sprintf("OpenWebUI-%s-%d", cfg.Proxy.ListenAddress, cfg.Proxy.ListenPort)
+}
+
+func runProxyEnable(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Resolve(nil)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	client, err := newNetshClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	rule := proxyRuleFromConfig(cfg)
+
+	if err := client.AddPortProxy(ctx, rule); err != nil {
+		return fmt.Errorf("add port proxy: %w", err)
+	}
+
+	if err := client.AddFirewallRule(ctx, firewallRuleName(cfg), cfg.Proxy.ListenPort); err != nil {
+		return fmt.Errorf("add firewall rule: %w", err)
+	}
+
+	fmt.Printf("Port proxy enabled: %s:%d -> %s:%d\n",
+		rule.ListenAddress, rule.ListenPort,
+		rule.ConnectAddress, rule.ConnectPort)
+	return nil
+}
+
+func runProxyRemove(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Resolve(nil)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	client, err := newNetshClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+
+	if err := client.RemovePortProxy(ctx, cfg.Proxy.ListenAddress, cfg.Proxy.ListenPort); err != nil {
+		return fmt.Errorf("remove port proxy: %w", err)
+	}
+
+	if err := client.RemoveFirewallRule(ctx, firewallRuleName(cfg)); err != nil {
+		return fmt.Errorf("remove firewall rule: %w", err)
+	}
+
+	return nil
+}
+
+func runProxyShow(cmd *cobra.Command, args []string) error {
+	client, err := newNetshClient()
+	if err != nil {
+		return err
+	}
+
+	rules, err := client.ListPortProxy(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	if len(rules) == 0 {
+		fmt.Println("No port proxy rules found.")
+		return nil
+	}
+
+	fmt.Printf("%-20s %-10s %-20s %-10s\n", "Listen Address", "Port", "Connect Address", "Port")
+	fmt.Printf("%-20s %-10s %-20s %-10s\n", "----", "----", "----", "----")
+	for _, r := range rules {
+		fmt.Printf("%-20s %-10d %-20s %-10d\n",
+			r.ListenAddress, r.ListenPort,
+			r.ConnectAddress, r.ConnectPort)
+	}
+	return nil
+}

--- a/cmd/ow/proxy_cmd_test.go
+++ b/cmd/ow/proxy_cmd_test.go
@@ -1,0 +1,63 @@
+//go:build windows
+
+package main
+
+import (
+	"testing"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+)
+
+func TestProxySubcommandRegistration(t *testing.T) {
+	subs := proxyCmd.Commands()
+	names := make(map[string]bool, len(subs))
+	for _, s := range subs {
+		names[s.Use] = true
+	}
+
+	for _, want := range []string{"enable", "remove", "show"} {
+		if !names[want] {
+			t.Errorf("missing subcommand %q in proxy command", want)
+		}
+	}
+}
+
+func TestProxyCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "proxy" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("proxy command not registered on rootCmd")
+	}
+}
+
+func TestProxyRuleFromConfig(t *testing.T) {
+	cfg := config.Defaults()
+	rule := proxyRuleFromConfig(cfg)
+
+	if rule.ListenAddress != "0.0.0.0" {
+		t.Errorf("ListenAddress = %q, want %q", rule.ListenAddress, "0.0.0.0")
+	}
+	if rule.ListenPort != 3000 {
+		t.Errorf("ListenPort = %d, want %d", rule.ListenPort, 3000)
+	}
+	if rule.ConnectAddress != "127.0.0.1" {
+		t.Errorf("ConnectAddress = %q, want %q", rule.ConnectAddress, "127.0.0.1")
+	}
+	if rule.ConnectPort != 3000 {
+		t.Errorf("ConnectPort = %d, want %d", rule.ConnectPort, 3000)
+	}
+}
+
+func TestFirewallRuleName(t *testing.T) {
+	cfg := config.Defaults()
+	name := firewallRuleName(cfg)
+	want := "OpenWebUI-0.0.0.0-3000"
+	if name != want {
+		t.Errorf("firewallRuleName = %q, want %q", name, want)
+	}
+}

--- a/cmd/ow/setup_windows.go
+++ b/cmd/ow/setup_windows.go
@@ -1,0 +1,115 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/netsh"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/winfeature"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/wsl"
+	"github.com/spf13/cobra"
+)
+
+var setupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Full Windows setup: WSL2, Ubuntu, Linux setup, port proxy",
+	Long: `Runs the complete Windows setup sequence matching RUNME.ps1:
+  1. Enable Windows features (WSL, VirtualMachinePlatform)
+  2. Install/update WSL2, set default version to 2
+  3. Install Ubuntu distribution
+  4. Run Linux setup inside WSL via ow setup
+  5. Enable port proxy and firewall rule
+  6. Print access URL`,
+	RunE: runSetup,
+}
+
+func init() {
+	rootCmd.AddCommand(setupCmd)
+}
+
+func runSetup(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Resolve(nil)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	logger, err := logging.NewLogger("", logging.Info)
+	if err != nil {
+		return fmt.Errorf("creating logger: %w", err)
+	}
+
+	runner := &exec.RealRunner{Logger: logger}
+	ctx := cmd.Context()
+
+	featureMgr := winfeature.NewManager(runner, logger)
+	wslMgr := wsl.NewManager(runner, logger)
+	netshClient := netsh.NewClient(runner, logger)
+
+	// Step 1: Enable Windows features.
+	logger.Info("step 1/6: enabling Windows features")
+	rebootNeeded, err := featureMgr.EnableWSLFeatures(ctx)
+	if err != nil {
+		return fmt.Errorf("enable WSL features: %w", err)
+	}
+	if rebootNeeded {
+		fmt.Println("Windows features were enabled. Please reboot and re-run ow setup.")
+		return nil
+	}
+
+	// Step 2: Install/update WSL2.
+	logger.Info("step 2/6: installing and updating WSL2")
+	installed, err := wslMgr.IsInstalled(ctx)
+	if err != nil {
+		return fmt.Errorf("check WSL: %w", err)
+	}
+	if !installed {
+		if err := wslMgr.Install(ctx); err != nil {
+			return fmt.Errorf("install WSL: %w", err)
+		}
+	}
+	if err := wslMgr.Update(ctx); err != nil {
+		return fmt.Errorf("update WSL: %w", err)
+	}
+	if err := wslMgr.SetDefaultVersion(ctx, 2); err != nil {
+		return fmt.Errorf("set WSL version: %w", err)
+	}
+
+	// Step 3: Install Ubuntu distribution.
+	logger.Info("step 3/6: installing %s distribution", cfg.WSL.Distro)
+	distroInstalled, err := wslMgr.IsDistroInstalled(ctx, cfg.WSL.Distro)
+	if err != nil {
+		return fmt.Errorf("check distro: %w", err)
+	}
+	if !distroInstalled {
+		if err := wslMgr.InstallDistro(ctx, cfg.WSL.Distro); err != nil {
+			return fmt.Errorf("install distro: %w", err)
+		}
+	}
+
+	// Step 4: Run Linux setup inside WSL.
+	logger.Info("step 4/6: running Linux setup inside WSL")
+	if _, err := wslMgr.RunCommand(ctx, cfg.WSL.Distro, "ow", "setup"); err != nil {
+		return fmt.Errorf("wsl ow setup: %w", err)
+	}
+
+	// Step 5: Enable port proxy and firewall.
+	logger.Info("step 5/6: enabling port proxy and firewall rule")
+	rule := proxyRuleFromConfig(cfg)
+	if err := netshClient.AddPortProxy(ctx, rule); err != nil {
+		return fmt.Errorf("add port proxy: %w", err)
+	}
+	if err := netshClient.AddFirewallRule(ctx, firewallRuleName(cfg), cfg.Proxy.ListenPort); err != nil {
+		return fmt.Errorf("add firewall rule: %w", err)
+	}
+
+	// Step 6: Print access URL.
+	logger.Info("step 6/6: setup complete")
+	fmt.Printf("\nOpenWebUI is available at: http://%s:%d\n",
+		cfg.Proxy.ListenAddress, cfg.Proxy.ListenPort)
+
+	return nil
+}

--- a/cmd/ow/setup_windows_test.go
+++ b/cmd/ow/setup_windows_test.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package main
+
+import (
+	"testing"
+)
+
+func TestSetupCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "setup" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("setup command not registered on rootCmd")
+	}
+}
+
+func TestSetupCommandDescription(t *testing.T) {
+	if setupCmd.Short == "" {
+		t.Error("setup command has no short description")
+	}
+	if setupCmd.Long == "" {
+		t.Error("setup command has no long description")
+	}
+}

--- a/cmd/ow/wsl_cmd.go
+++ b/cmd/ow/wsl_cmd.go
@@ -1,0 +1,124 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/config"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/wsl"
+	"github.com/spf13/cobra"
+)
+
+var wslCmd = &cobra.Command{
+	Use:   "wsl",
+	Short: "Manage WSL2 and distributions",
+}
+
+var wslInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install WSL2 and the configured distribution",
+	RunE:  runWslInstall,
+}
+
+var wslRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Unregister the configured WSL distribution",
+	RunE:  runWslRemove,
+}
+
+var wslStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Shut down all running WSL distributions",
+	RunE:  runWslStop,
+}
+
+func init() {
+	rootCmd.AddCommand(wslCmd)
+	wslCmd.AddCommand(wslInstallCmd)
+	wslCmd.AddCommand(wslRemoveCmd)
+	wslCmd.AddCommand(wslStopCmd)
+}
+
+func newWslManager() (*wsl.Manager, error) {
+	logger, err := logging.NewLogger("", logging.Info)
+	if err != nil {
+		return nil, fmt.Errorf("creating logger: %w", err)
+	}
+	runner := &exec.RealRunner{Logger: logger}
+	return wsl.NewManager(runner, logger), nil
+}
+
+func runWslInstall(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Resolve(nil)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	mgr, err := newWslManager()
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+
+	// Install WSL if needed.
+	installed, err := mgr.IsInstalled(ctx)
+	if err != nil {
+		return fmt.Errorf("checking WSL: %w", err)
+	}
+	if !installed {
+		if err := mgr.Install(ctx); err != nil {
+			return err
+		}
+	}
+
+	// Update WSL.
+	if err := mgr.Update(ctx); err != nil {
+		return err
+	}
+
+	// Set default version to 2.
+	if err := mgr.SetDefaultVersion(ctx, 2); err != nil {
+		return err
+	}
+
+	// Install distro if needed.
+	distro := cfg.WSL.Distro
+	distroInstalled, err := mgr.IsDistroInstalled(ctx, distro)
+	if err != nil {
+		return fmt.Errorf("checking distro: %w", err)
+	}
+	if !distroInstalled {
+		if err := mgr.InstallDistro(ctx, distro); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func runWslRemove(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Resolve(nil)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	mgr, err := newWslManager()
+	if err != nil {
+		return err
+	}
+
+	return mgr.RemoveDistro(cmd.Context(), cfg.WSL.Distro)
+}
+
+func runWslStop(cmd *cobra.Command, args []string) error {
+	mgr, err := newWslManager()
+	if err != nil {
+		return err
+	}
+
+	return mgr.Stop(cmd.Context())
+}

--- a/cmd/ow/wsl_cmd_test.go
+++ b/cmd/ow/wsl_cmd_test.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package main
+
+import (
+	"testing"
+)
+
+func TestWslSubcommandRegistration(t *testing.T) {
+	subs := wslCmd.Commands()
+	names := make(map[string]bool, len(subs))
+	for _, s := range subs {
+		names[s.Use] = true
+	}
+
+	for _, want := range []string{"install", "remove", "stop"} {
+		if !names[want] {
+			t.Errorf("missing subcommand %q in wsl command", want)
+		}
+	}
+}
+
+func TestWslCommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "wsl" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("wsl command not registered on rootCmd")
+	}
+}

--- a/internal/netsh/firewall.go
+++ b/internal/netsh/firewall.go
@@ -1,0 +1,59 @@
+//go:build windows
+
+package netsh
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// AddFirewallRule creates an inbound TCP firewall rule via netsh advfirewall.
+// Skips if a rule with the same name already exists.
+func (c *Client) AddFirewallRule(ctx context.Context, name string, port int) error {
+	exists, err := c.FirewallRuleExists(ctx, name)
+	if err != nil {
+		c.Logger.Warn("could not check firewall rule: %v", err)
+	}
+	if exists {
+		c.Logger.Info("firewall rule %q already exists, skipping", name)
+		return nil
+	}
+
+	c.Logger.Info("adding firewall rule %q for TCP port %d", name, port)
+	_, err = c.Runner.Run(ctx, "netsh", "advfirewall", "firewall", "add", "rule",
+		fmt.Sprintf("name=%s", name),
+		"dir=in",
+		"action=allow",
+		"protocol=TCP",
+		fmt.Sprintf("localport=%d", port))
+	if err != nil {
+		return fmt.Errorf("netsh add firewall rule: %w", err)
+	}
+	return nil
+}
+
+// RemoveFirewallRule deletes a firewall rule by name.
+func (c *Client) RemoveFirewallRule(ctx context.Context, name string) error {
+	c.Logger.Info("removing firewall rule %q", name)
+	_, err := c.Runner.Run(ctx, "netsh", "advfirewall", "firewall", "delete", "rule",
+		fmt.Sprintf("name=%s", name))
+	if err != nil {
+		return fmt.Errorf("netsh delete firewall rule: %w", err)
+	}
+	return nil
+}
+
+// FirewallRuleExists returns true if a firewall rule with the given name exists.
+func (c *Client) FirewallRuleExists(ctx context.Context, name string) (bool, error) {
+	out, err := c.Runner.Run(ctx, "netsh", "advfirewall", "firewall", "show", "rule",
+		fmt.Sprintf("name=%s", name))
+	if err != nil {
+		// netsh exits non-zero when no matching rule is found.
+		if strings.Contains(out, "No rules match") {
+			return false, nil
+		}
+		return false, fmt.Errorf("netsh show firewall rule: %w", err)
+	}
+	return true, nil
+}

--- a/internal/netsh/proxy.go
+++ b/internal/netsh/proxy.go
@@ -1,0 +1,144 @@
+//go:build windows
+
+// Package netsh manages Windows port proxy and firewall rules via netsh.
+package netsh
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+// ProxyRule represents a single v4tov4 port proxy rule.
+type ProxyRule struct {
+	ListenAddress  string
+	ListenPort     int
+	ConnectAddress string
+	ConnectPort    int
+}
+
+// Client manages netsh operations.
+type Client struct {
+	Runner exec.Runner
+	Logger *logging.Logger
+}
+
+// NewClient creates a Client with the given runner and logger.
+func NewClient(runner exec.Runner, logger *logging.Logger) *Client {
+	return &Client{Runner: runner, Logger: logger}
+}
+
+// AddPortProxy creates a v4tov4 port proxy rule. If a rule already exists
+// for the same listen address and port, it is removed first.
+func (c *Client) AddPortProxy(ctx context.Context, rule ProxyRule) error {
+	// Check for existing rule and remove if different.
+	existing, err := c.ListPortProxy(ctx)
+	if err != nil {
+		c.Logger.Warn("could not list existing proxy rules: %v", err)
+	}
+
+	for _, r := range existing {
+		if r.ListenAddress == rule.ListenAddress && r.ListenPort == rule.ListenPort {
+			if r.ConnectAddress == rule.ConnectAddress && r.ConnectPort == rule.ConnectPort {
+				c.Logger.Info("port proxy rule already exists, skipping")
+				return nil
+			}
+			c.Logger.Info("removing conflicting proxy rule for %s:%d",
+				rule.ListenAddress, rule.ListenPort)
+			if err := c.RemovePortProxy(ctx, rule.ListenAddress, rule.ListenPort); err != nil {
+				return fmt.Errorf("remove conflicting rule: %w", err)
+			}
+		}
+	}
+
+	c.Logger.Info("adding port proxy %s:%d -> %s:%d",
+		rule.ListenAddress, rule.ListenPort,
+		rule.ConnectAddress, rule.ConnectPort)
+
+	_, err = c.Runner.Run(ctx, "netsh", "interface", "portproxy", "add", "v4tov4",
+		fmt.Sprintf("listenaddress=%s", rule.ListenAddress),
+		fmt.Sprintf("listenport=%d", rule.ListenPort),
+		fmt.Sprintf("connectaddress=%s", rule.ConnectAddress),
+		fmt.Sprintf("connectport=%d", rule.ConnectPort))
+	if err != nil {
+		return fmt.Errorf("netsh add portproxy: %w", err)
+	}
+
+	return nil
+}
+
+// RemovePortProxy deletes a v4tov4 port proxy rule.
+func (c *Client) RemovePortProxy(ctx context.Context, listenAddr string, listenPort int) error {
+	c.Logger.Info("removing port proxy for %s:%d", listenAddr, listenPort)
+	_, err := c.Runner.Run(ctx, "netsh", "interface", "portproxy", "delete", "v4tov4",
+		fmt.Sprintf("listenaddress=%s", listenAddr),
+		fmt.Sprintf("listenport=%d", listenPort))
+	if err != nil {
+		return fmt.Errorf("netsh delete portproxy: %w", err)
+	}
+	return nil
+}
+
+// ListPortProxy returns all v4tov4 port proxy rules.
+func (c *Client) ListPortProxy(ctx context.Context) ([]ProxyRule, error) {
+	out, err := c.Runner.Run(ctx, "netsh", "interface", "portproxy", "show", "v4tov4")
+	if err != nil {
+		return nil, fmt.Errorf("netsh show portproxy: %w", err)
+	}
+	return parseProxyRules(out), nil
+}
+
+// PortProxyExists returns true if a proxy rule exists for the given listen
+// address and port.
+func (c *Client) PortProxyExists(ctx context.Context, listenAddr string, listenPort int) (bool, error) {
+	rules, err := c.ListPortProxy(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, r := range rules {
+		if r.ListenAddress == listenAddr && r.ListenPort == listenPort {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// proxyPattern matches netsh portproxy output lines like:
+// "0.0.0.0         3000         127.0.0.1       3000"
+// or the colon-separated format:
+// "0.0.0.0:3000        127.0.0.1:3000"
+var proxyPattern = regexp.MustCompile(
+	`^(\d{1,3}(?:\.\d{1,3}){3})\s+(\d+)\s+(\d{1,3}(?:\.\d{1,3}){3})\s+(\d+)$`)
+
+// parseProxyRules extracts ProxyRule entries from netsh portproxy output.
+// The output format is a header followed by data lines:
+//
+//	Listen on ipv4:             Connect to ipv4:
+//
+//	Address         Port        Address         Port
+//	--------------- ----------  --------------- ----------
+//	0.0.0.0         3000        127.0.0.1       3000
+func parseProxyRules(output string) []ProxyRule {
+	var rules []ProxyRule
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		m := proxyPattern.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		var lport, cport int
+		fmt.Sscanf(m[2], "%d", &lport)
+		fmt.Sscanf(m[4], "%d", &cport)
+		rules = append(rules, ProxyRule{
+			ListenAddress:  m[1],
+			ListenPort:     lport,
+			ConnectAddress: m[3],
+			ConnectPort:    cport,
+		})
+	}
+	return rules
+}

--- a/internal/netsh/proxy_test.go
+++ b/internal/netsh/proxy_test.go
@@ -1,0 +1,314 @@
+//go:build windows
+
+package netsh
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+type mockCall struct {
+	Name string
+	Args []string
+}
+
+type mockRunner struct {
+	calls   []mockCall
+	outputs map[string]string
+	errors  map[string]error
+}
+
+func newMockRunner() *mockRunner {
+	return &mockRunner{
+		outputs: make(map[string]string),
+		errors:  make(map[string]error),
+	}
+}
+
+func (r *mockRunner) key(name string, args ...string) string {
+	parts := append([]string{name}, args...)
+	return strings.Join(parts, " ")
+}
+
+func (r *mockRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	r.calls = append(r.calls, mockCall{Name: name, Args: args})
+	k := r.key(name, args...)
+	if err, ok := r.errors[k]; ok {
+		return r.outputs[k], err
+	}
+	return r.outputs[k], nil
+}
+
+func (r *mockRunner) RunWithRetry(ctx context.Context, _ exec.RetryOpts, name string, args ...string) (string, error) {
+	return r.Run(ctx, name, args...)
+}
+
+func (r *mockRunner) called(name string, args ...string) bool {
+	k := r.key(name, args...)
+	for _, c := range r.calls {
+		ck := r.key(c.Name, c.Args...)
+		if ck == k {
+			return true
+		}
+	}
+	return false
+}
+
+func newTestLogger(t *testing.T) *logging.Logger {
+	t.Helper()
+	var buf bytes.Buffer
+	l, err := logging.NewLoggerWithWriter(&buf, "", logging.Debug2)
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+	return l
+}
+
+func TestParseProxyRulesEmpty(t *testing.T) {
+	rules := parseProxyRules("")
+	if len(rules) != 0 {
+		t.Errorf("expected 0 rules, got %d", len(rules))
+	}
+}
+
+func TestParseProxyRulesTypicalOutput(t *testing.T) {
+	output := `
+Listen on ipv4:             Connect to ipv4:
+
+Address         Port        Address         Port
+--------------- ----------  --------------- ----------
+0.0.0.0         3000        127.0.0.1       3000
+192.168.1.1     8080        10.0.0.1        80
+`
+	rules := parseProxyRules(output)
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d", len(rules))
+	}
+
+	if rules[0].ListenAddress != "0.0.0.0" || rules[0].ListenPort != 3000 {
+		t.Errorf("rule 0 listen: got %s:%d", rules[0].ListenAddress, rules[0].ListenPort)
+	}
+	if rules[0].ConnectAddress != "127.0.0.1" || rules[0].ConnectPort != 3000 {
+		t.Errorf("rule 0 connect: got %s:%d", rules[0].ConnectAddress, rules[0].ConnectPort)
+	}
+
+	if rules[1].ListenAddress != "192.168.1.1" || rules[1].ListenPort != 8080 {
+		t.Errorf("rule 1 listen: got %s:%d", rules[1].ListenAddress, rules[1].ListenPort)
+	}
+}
+
+func TestParseProxyRulesHeaderOnly(t *testing.T) {
+	output := `Listen on ipv4:             Connect to ipv4:
+
+Address         Port        Address         Port
+--------------- ----------  --------------- ----------
+`
+	rules := parseProxyRules(output)
+	if len(rules) != 0 {
+		t.Errorf("expected 0 rules, got %d", len(rules))
+	}
+}
+
+func TestAddPortProxySkipsWhenExists(t *testing.T) {
+	r := newMockRunner()
+	showKey := r.key("netsh", "interface", "portproxy", "show", "v4tov4")
+	r.outputs[showKey] = "0.0.0.0         3000        127.0.0.1       3000\n"
+
+	c := NewClient(r, newTestLogger(t))
+	err := c.AddPortProxy(context.Background(), ProxyRule{
+		ListenAddress:  "0.0.0.0",
+		ListenPort:     3000,
+		ConnectAddress: "127.0.0.1",
+		ConnectPort:    3000,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should NOT have called add.
+	if r.called("netsh", "interface", "portproxy", "add", "v4tov4",
+		"listenaddress=0.0.0.0", "listenport=3000",
+		"connectaddress=127.0.0.1", "connectport=3000") {
+		t.Error("should not add when rule already exists")
+	}
+}
+
+func TestAddPortProxyCreatesNewRule(t *testing.T) {
+	r := newMockRunner()
+	showKey := r.key("netsh", "interface", "portproxy", "show", "v4tov4")
+	r.outputs[showKey] = "" // no existing rules
+
+	c := NewClient(r, newTestLogger(t))
+	err := c.AddPortProxy(context.Background(), ProxyRule{
+		ListenAddress:  "0.0.0.0",
+		ListenPort:     3000,
+		ConnectAddress: "127.0.0.1",
+		ConnectPort:    3000,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !r.called("netsh", "interface", "portproxy", "add", "v4tov4",
+		"listenaddress=0.0.0.0", "listenport=3000",
+		"connectaddress=127.0.0.1", "connectport=3000") {
+		t.Error("expected netsh add portproxy call")
+	}
+}
+
+func TestAddPortProxyRemovesConflicting(t *testing.T) {
+	r := newMockRunner()
+	showKey := r.key("netsh", "interface", "portproxy", "show", "v4tov4")
+	// Existing rule has different connect address.
+	r.outputs[showKey] = "0.0.0.0         3000        10.0.0.1        3000\n"
+
+	c := NewClient(r, newTestLogger(t))
+	err := c.AddPortProxy(context.Background(), ProxyRule{
+		ListenAddress:  "0.0.0.0",
+		ListenPort:     3000,
+		ConnectAddress: "127.0.0.1",
+		ConnectPort:    3000,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have called delete first.
+	if !r.called("netsh", "interface", "portproxy", "delete", "v4tov4",
+		"listenaddress=0.0.0.0", "listenport=3000") {
+		t.Error("expected delete of conflicting rule")
+	}
+}
+
+func TestRemovePortProxy(t *testing.T) {
+	r := newMockRunner()
+	c := NewClient(r, newTestLogger(t))
+
+	err := c.RemovePortProxy(context.Background(), "0.0.0.0", 3000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !r.called("netsh", "interface", "portproxy", "delete", "v4tov4",
+		"listenaddress=0.0.0.0", "listenport=3000") {
+		t.Error("expected netsh delete call")
+	}
+}
+
+func TestPortProxyExistsTrue(t *testing.T) {
+	r := newMockRunner()
+	showKey := r.key("netsh", "interface", "portproxy", "show", "v4tov4")
+	r.outputs[showKey] = "0.0.0.0         3000        127.0.0.1       3000\n"
+
+	c := NewClient(r, newTestLogger(t))
+	exists, err := c.PortProxyExists(context.Background(), "0.0.0.0", 3000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Error("expected true")
+	}
+}
+
+func TestPortProxyExistsFalse(t *testing.T) {
+	r := newMockRunner()
+	showKey := r.key("netsh", "interface", "portproxy", "show", "v4tov4")
+	r.outputs[showKey] = ""
+
+	c := NewClient(r, newTestLogger(t))
+	exists, err := c.PortProxyExists(context.Background(), "0.0.0.0", 3000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exists {
+		t.Error("expected false")
+	}
+}
+
+func TestAddFirewallRuleSkipsWhenExists(t *testing.T) {
+	r := newMockRunner()
+	showKey := r.key("netsh", "advfirewall", "firewall", "show", "rule", "name=OpenWebUI-3000")
+	r.outputs[showKey] = "Rule Name: OpenWebUI-3000\n"
+
+	c := NewClient(r, newTestLogger(t))
+	err := c.AddFirewallRule(context.Background(), "OpenWebUI-3000", 3000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should NOT have called add.
+	for _, call := range r.calls {
+		if call.Name == "netsh" && len(call.Args) > 2 && call.Args[2] == "add" {
+			t.Error("should not add firewall rule when it already exists")
+		}
+	}
+}
+
+func TestAddFirewallRuleCreatesNew(t *testing.T) {
+	r := newMockRunner()
+	showKey := r.key("netsh", "advfirewall", "firewall", "show", "rule", "name=OpenWebUI-3000")
+	r.outputs[showKey] = "No rules match the specified criteria."
+	r.errors[showKey] = fmt.Errorf("exit status 1")
+
+	c := NewClient(r, newTestLogger(t))
+	err := c.AddFirewallRule(context.Background(), "OpenWebUI-3000", 3000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !r.called("netsh", "advfirewall", "firewall", "add", "rule",
+		"name=OpenWebUI-3000", "dir=in", "action=allow", "protocol=TCP", "localport=3000") {
+		t.Error("expected netsh add firewall rule call")
+	}
+}
+
+func TestRemoveFirewallRule(t *testing.T) {
+	r := newMockRunner()
+	c := NewClient(r, newTestLogger(t))
+
+	err := c.RemoveFirewallRule(context.Background(), "OpenWebUI-3000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !r.called("netsh", "advfirewall", "firewall", "delete", "rule", "name=OpenWebUI-3000") {
+		t.Error("expected netsh delete firewall rule call")
+	}
+}
+
+func TestFirewallRuleExistsTrue(t *testing.T) {
+	r := newMockRunner()
+	showKey := r.key("netsh", "advfirewall", "firewall", "show", "rule", "name=Test")
+	r.outputs[showKey] = "Rule Name: Test\nEnabled: Yes\n"
+
+	c := NewClient(r, newTestLogger(t))
+	exists, err := c.FirewallRuleExists(context.Background(), "Test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Error("expected true")
+	}
+}
+
+func TestFirewallRuleExistsFalse(t *testing.T) {
+	r := newMockRunner()
+	showKey := r.key("netsh", "advfirewall", "firewall", "show", "rule", "name=Missing")
+	r.outputs[showKey] = "No rules match the specified criteria."
+	r.errors[showKey] = fmt.Errorf("exit status 1")
+
+	c := NewClient(r, newTestLogger(t))
+	exists, err := c.FirewallRuleExists(context.Background(), "Missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exists {
+		t.Error("expected false")
+	}
+}

--- a/internal/winfeature/features.go
+++ b/internal/winfeature/features.go
@@ -1,0 +1,87 @@
+//go:build windows
+
+// Package winfeature manages Windows optional features via powershell.exe.
+package winfeature
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+const (
+	featureWSL = "Microsoft-Windows-Subsystem-Linux"
+	featureVMP = "VirtualMachinePlatform"
+)
+
+// Manager handles Windows optional feature operations via powershell.exe.
+type Manager struct {
+	Runner exec.Runner
+	Logger *logging.Logger
+}
+
+// NewManager creates a Manager with the given runner and logger.
+func NewManager(runner exec.Runner, logger *logging.Logger) *Manager {
+	return &Manager{Runner: runner, Logger: logger}
+}
+
+// IsEnabled returns true if the named Windows optional feature is enabled.
+func (m *Manager) IsEnabled(ctx context.Context, feature string) (bool, error) {
+	out, err := m.Runner.Run(ctx, "powershell.exe", "-Command",
+		fmt.Sprintf("(Get-WindowsOptionalFeature -FeatureName %s -Online).State", feature))
+	if err != nil {
+		return false, fmt.Errorf("check feature %s: %w", feature, err)
+	}
+	return strings.TrimSpace(out) == "Enabled", nil
+}
+
+// Enable enables a Windows optional feature without restarting.
+func (m *Manager) Enable(ctx context.Context, feature string) error {
+	m.Logger.Info("enabling Windows feature: %s", feature)
+	_, err := m.Runner.Run(ctx, "powershell.exe", "-Command",
+		fmt.Sprintf("Enable-WindowsOptionalFeature -Online -FeatureName %s -NoRestart", feature))
+	if err != nil {
+		return fmt.Errorf("enable feature %s: %w", feature, err)
+	}
+	m.Logger.Info("feature %s enabled", feature)
+	return nil
+}
+
+// EnableIfNeeded checks if a feature is enabled and enables it if not.
+// Returns true if the feature was newly enabled (reboot may be required).
+func (m *Manager) EnableIfNeeded(ctx context.Context, feature string) (bool, error) {
+	enabled, err := m.IsEnabled(ctx, feature)
+	if err != nil {
+		return false, err
+	}
+	if enabled {
+		m.Logger.Info("feature %s is already enabled", feature)
+		return false, nil
+	}
+	if err := m.Enable(ctx, feature); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// EnableWSLFeatures enables both features required for WSL2:
+// Microsoft-Windows-Subsystem-Linux and VirtualMachinePlatform.
+// Returns true if any feature was newly enabled (reboot may be required).
+func (m *Manager) EnableWSLFeatures(ctx context.Context) (bool, error) {
+	m.Logger.Info("enabling required WSL features")
+
+	wslEnabled, err := m.EnableIfNeeded(ctx, featureWSL)
+	if err != nil {
+		return false, err
+	}
+
+	vmpEnabled, err := m.EnableIfNeeded(ctx, featureVMP)
+	if err != nil {
+		return false, err
+	}
+
+	return wslEnabled || vmpEnabled, nil
+}

--- a/internal/winfeature/features_test.go
+++ b/internal/winfeature/features_test.go
@@ -1,0 +1,187 @@
+//go:build windows
+
+package winfeature
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+type mockCall struct {
+	Name string
+	Args []string
+}
+
+type mockRunner struct {
+	calls   []mockCall
+	outputs map[string]string
+	errors  map[string]error
+}
+
+func newMockRunner() *mockRunner {
+	return &mockRunner{
+		outputs: make(map[string]string),
+		errors:  make(map[string]error),
+	}
+}
+
+func (r *mockRunner) key(name string, args ...string) string {
+	parts := append([]string{name}, args...)
+	return strings.Join(parts, " ")
+}
+
+func (r *mockRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	r.calls = append(r.calls, mockCall{Name: name, Args: args})
+	k := r.key(name, args...)
+	if err, ok := r.errors[k]; ok {
+		return r.outputs[k], err
+	}
+	return r.outputs[k], nil
+}
+
+func (r *mockRunner) RunWithRetry(ctx context.Context, _ exec.RetryOpts, name string, args ...string) (string, error) {
+	return r.Run(ctx, name, args...)
+}
+
+func (r *mockRunner) callCount() int {
+	return len(r.calls)
+}
+
+func newTestLogger(t *testing.T) *logging.Logger {
+	t.Helper()
+	var buf bytes.Buffer
+	l, err := logging.NewLoggerWithWriter(&buf, "", logging.Debug2)
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+	return l
+}
+
+func TestIsEnabledTrue(t *testing.T) {
+	r := newMockRunner()
+	checkKey := r.key("powershell.exe", "-Command",
+		"(Get-WindowsOptionalFeature -FeatureName Microsoft-Windows-Subsystem-Linux -Online).State")
+	r.outputs[checkKey] = "Enabled\n"
+
+	mgr := NewManager(r, newTestLogger(t))
+	enabled, err := mgr.IsEnabled(context.Background(), featureWSL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Error("expected true")
+	}
+}
+
+func TestIsEnabledFalse(t *testing.T) {
+	r := newMockRunner()
+	checkKey := r.key("powershell.exe", "-Command",
+		"(Get-WindowsOptionalFeature -FeatureName VirtualMachinePlatform -Online).State")
+	r.outputs[checkKey] = "Disabled\n"
+
+	mgr := NewManager(r, newTestLogger(t))
+	enabled, err := mgr.IsEnabled(context.Background(), featureVMP)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enabled {
+		t.Error("expected false")
+	}
+}
+
+func TestEnableIfNeededSkipsWhenEnabled(t *testing.T) {
+	r := newMockRunner()
+	checkKey := r.key("powershell.exe", "-Command",
+		"(Get-WindowsOptionalFeature -FeatureName Microsoft-Windows-Subsystem-Linux -Online).State")
+	r.outputs[checkKey] = "Enabled\n"
+
+	mgr := NewManager(r, newTestLogger(t))
+	changed, err := mgr.EnableIfNeeded(context.Background(), featureWSL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Error("expected false (already enabled)")
+	}
+	// Should only check, not enable.
+	if r.callCount() != 1 {
+		t.Errorf("expected 1 call (check only), got %d", r.callCount())
+	}
+}
+
+func TestEnableIfNeededEnablesWhenDisabled(t *testing.T) {
+	r := newMockRunner()
+	checkKey := r.key("powershell.exe", "-Command",
+		"(Get-WindowsOptionalFeature -FeatureName VirtualMachinePlatform -Online).State")
+	r.outputs[checkKey] = "Disabled\n"
+
+	mgr := NewManager(r, newTestLogger(t))
+	changed, err := mgr.EnableIfNeeded(context.Background(), featureVMP)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("expected true (newly enabled)")
+	}
+	// Should check then enable.
+	if r.callCount() != 2 {
+		t.Errorf("expected 2 calls (check + enable), got %d", r.callCount())
+	}
+}
+
+func TestEnableWSLFeaturesAllEnabled(t *testing.T) {
+	r := newMockRunner()
+	wslKey := r.key("powershell.exe", "-Command",
+		"(Get-WindowsOptionalFeature -FeatureName Microsoft-Windows-Subsystem-Linux -Online).State")
+	vmpKey := r.key("powershell.exe", "-Command",
+		"(Get-WindowsOptionalFeature -FeatureName VirtualMachinePlatform -Online).State")
+	r.outputs[wslKey] = "Enabled\n"
+	r.outputs[vmpKey] = "Enabled\n"
+
+	mgr := NewManager(r, newTestLogger(t))
+	changed, err := mgr.EnableWSLFeatures(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Error("expected false (both already enabled)")
+	}
+}
+
+func TestEnableWSLFeaturesOneDisabled(t *testing.T) {
+	r := newMockRunner()
+	wslKey := r.key("powershell.exe", "-Command",
+		"(Get-WindowsOptionalFeature -FeatureName Microsoft-Windows-Subsystem-Linux -Online).State")
+	vmpKey := r.key("powershell.exe", "-Command",
+		"(Get-WindowsOptionalFeature -FeatureName VirtualMachinePlatform -Online).State")
+	r.outputs[wslKey] = "Enabled\n"
+	r.outputs[vmpKey] = "Disabled\n"
+
+	mgr := NewManager(r, newTestLogger(t))
+	changed, err := mgr.EnableWSLFeatures(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("expected true (one was disabled)")
+	}
+}
+
+func TestIsEnabledError(t *testing.T) {
+	r := newMockRunner()
+	checkKey := r.key("powershell.exe", "-Command",
+		"(Get-WindowsOptionalFeature -FeatureName BadFeature -Online).State")
+	r.errors[checkKey] = fmt.Errorf("feature not found")
+
+	mgr := NewManager(r, newTestLogger(t))
+	_, err := mgr.IsEnabled(context.Background(), "BadFeature")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/wsl/wsl.go
+++ b/internal/wsl/wsl.go
@@ -1,0 +1,148 @@
+//go:build windows
+
+// Package wsl manages WSL2 installation, updates, and lifecycle via wsl.exe.
+package wsl
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+// Manager handles WSL2 lifecycle operations by shelling out to wsl.exe.
+type Manager struct {
+	Runner exec.Runner
+	Logger *logging.Logger
+}
+
+// NewManager creates a Manager with the given runner and logger.
+func NewManager(runner exec.Runner, logger *logging.Logger) *Manager {
+	return &Manager{Runner: runner, Logger: logger}
+}
+
+// IsInstalled returns true if WSL is installed and functional.
+// It runs `wsl.exe --status` and checks for a zero exit code.
+func (m *Manager) IsInstalled(ctx context.Context) (bool, error) {
+	_, err := m.Runner.Run(ctx, "wsl.exe", "--status")
+	if err != nil {
+		return false, nil //nolint:nilerr // wsl --status exits non-zero when not installed
+	}
+	return true, nil
+}
+
+// Install installs WSL without a distribution.
+// The caller should install a distro separately.
+func (m *Manager) Install(ctx context.Context) error {
+	m.Logger.Info("installing WSL")
+	_, err := m.Runner.RunWithRetry(ctx, exec.DefaultRetryOpts(),
+		"wsl.exe", "--install", "--no-distribution")
+	if err != nil {
+		return fmt.Errorf("wsl install: %w", err)
+	}
+	m.Logger.Info("WSL installed")
+	return nil
+}
+
+// Update runs `wsl --update` to update the WSL kernel.
+func (m *Manager) Update(ctx context.Context) error {
+	m.Logger.Info("updating WSL")
+	_, err := m.Runner.RunWithRetry(ctx, exec.DefaultRetryOpts(),
+		"wsl.exe", "--update")
+	if err != nil {
+		return fmt.Errorf("wsl update: %w", err)
+	}
+	m.Logger.Info("WSL updated")
+	return nil
+}
+
+// SetDefaultVersion sets the default WSL version (1 or 2).
+func (m *Manager) SetDefaultVersion(ctx context.Context, version int) error {
+	m.Logger.Info("setting WSL default version to %d", version)
+	_, err := m.Runner.Run(ctx, "wsl.exe", "--set-default-version",
+		fmt.Sprintf("%d", version))
+	if err != nil {
+		return fmt.Errorf("wsl set-default-version: %w", err)
+	}
+	return nil
+}
+
+// Stop shuts down all running WSL distributions.
+func (m *Manager) Stop(ctx context.Context) error {
+	m.Logger.Info("shutting down WSL")
+	_, err := m.Runner.Run(ctx, "wsl.exe", "--shutdown")
+	if err != nil {
+		return fmt.Errorf("wsl shutdown: %w", err)
+	}
+	m.Logger.Info("WSL shut down")
+	return nil
+}
+
+// IsDistroInstalled returns true if the named distribution is registered.
+// It parses `wsl --list --verbose` output.
+func (m *Manager) IsDistroInstalled(ctx context.Context, name string) (bool, error) {
+	out, err := m.Runner.Run(ctx, "wsl.exe", "--list", "--verbose")
+	if err != nil {
+		// WSL not installed or no distros: treat as not installed.
+		return false, nil //nolint:nilerr // expected when WSL has no distros
+	}
+	return containsDistro(out, name), nil
+}
+
+// InstallDistro installs a WSL distribution. This is interactive: the user
+// must set a username and password. The caller should wire stdin/stdout
+// for terminal passthrough.
+func (m *Manager) InstallDistro(ctx context.Context, name string) error {
+	m.Logger.Info("installing WSL distribution: %s", name)
+	_, err := m.Runner.Run(ctx, "wsl.exe", "--install", "-d", name)
+	if err != nil {
+		return fmt.Errorf("wsl install distro %s: %w", name, err)
+	}
+
+	// Set as default distribution.
+	_, err = m.Runner.Run(ctx, "wsl.exe", "--setdefault", name)
+	if err != nil {
+		return fmt.Errorf("wsl setdefault %s: %w", name, err)
+	}
+
+	m.Logger.Info("distribution %s installed and set as default", name)
+	return nil
+}
+
+// RemoveDistro unregisters a WSL distribution, deleting its filesystem.
+func (m *Manager) RemoveDistro(ctx context.Context, name string) error {
+	m.Logger.Info("removing WSL distribution: %s", name)
+	_, err := m.Runner.Run(ctx, "wsl.exe", "--unregister", name)
+	if err != nil {
+		return fmt.Errorf("wsl unregister %s: %w", name, err)
+	}
+	m.Logger.Info("distribution %s removed", name)
+	return nil
+}
+
+// RunCommand executes a command inside a WSL distribution.
+func (m *Manager) RunCommand(ctx context.Context, distro string, cmd string, args ...string) (string, error) {
+	wslArgs := []string{"-d", distro, "--"}
+	wslArgs = append(wslArgs, cmd)
+	wslArgs = append(wslArgs, args...)
+	return m.Runner.Run(ctx, "wsl.exe", wslArgs...)
+}
+
+// containsDistro checks if a distro name appears in wsl --list --verbose output.
+// The output format has a header line followed by lines like:
+//
+//	* Ubuntu    Running  2
+//	  Debian    Stopped  2
+func containsDistro(output, name string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		// Strip leading *, spaces, and null bytes (wsl outputs UTF-16).
+		cleaned := strings.TrimLeft(line, "* \t\x00")
+		fields := strings.Fields(cleaned)
+		if len(fields) >= 1 && strings.EqualFold(fields[0], name) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/wsl/wsl_test.go
+++ b/internal/wsl/wsl_test.go
@@ -1,0 +1,271 @@
+//go:build windows
+
+package wsl
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/exec"
+	"github.com/rickeerickson/openwebui-wsl2-starter/internal/logging"
+)
+
+type mockCall struct {
+	Name string
+	Args []string
+}
+
+type mockRunner struct {
+	calls   []mockCall
+	outputs map[string]string
+	errors  map[string]error
+}
+
+func newMockRunner() *mockRunner {
+	return &mockRunner{
+		outputs: make(map[string]string),
+		errors:  make(map[string]error),
+	}
+}
+
+func (r *mockRunner) key(name string, args ...string) string {
+	parts := append([]string{name}, args...)
+	return strings.Join(parts, " ")
+}
+
+func (r *mockRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	r.calls = append(r.calls, mockCall{Name: name, Args: args})
+	k := r.key(name, args...)
+	if err, ok := r.errors[k]; ok {
+		return r.outputs[k], err
+	}
+	return r.outputs[k], nil
+}
+
+func (r *mockRunner) RunWithRetry(ctx context.Context, _ exec.RetryOpts, name string, args ...string) (string, error) {
+	return r.Run(ctx, name, args...)
+}
+
+func (r *mockRunner) called(name string, args ...string) bool {
+	k := r.key(name, args...)
+	for _, c := range r.calls {
+		ck := r.key(c.Name, c.Args...)
+		if ck == k {
+			return true
+		}
+	}
+	return false
+}
+
+func newTestLogger(t *testing.T) *logging.Logger {
+	t.Helper()
+	var buf bytes.Buffer
+	l, err := logging.NewLoggerWithWriter(&buf, "", logging.Debug2)
+	if err != nil {
+		t.Fatalf("create logger: %v", err)
+	}
+	return l
+}
+
+func TestIsInstalledTrue(t *testing.T) {
+	r := newMockRunner()
+	mgr := NewManager(r, newTestLogger(t))
+
+	installed, err := mgr.IsInstalled(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !installed {
+		t.Error("expected true")
+	}
+}
+
+func TestIsInstalledFalse(t *testing.T) {
+	r := newMockRunner()
+	r.errors[r.key("wsl.exe", "--status")] = fmt.Errorf("not installed")
+
+	mgr := NewManager(r, newTestLogger(t))
+	installed, err := mgr.IsInstalled(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if installed {
+		t.Error("expected false")
+	}
+}
+
+func TestInstallCallsWslInstall(t *testing.T) {
+	r := newMockRunner()
+	mgr := NewManager(r, newTestLogger(t))
+
+	err := mgr.Install(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !r.called("wsl.exe", "--install", "--no-distribution") {
+		t.Error("expected wsl.exe --install --no-distribution call")
+	}
+}
+
+func TestUpdateCallsWslUpdate(t *testing.T) {
+	r := newMockRunner()
+	mgr := NewManager(r, newTestLogger(t))
+
+	err := mgr.Update(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !r.called("wsl.exe", "--update") {
+		t.Error("expected wsl.exe --update call")
+	}
+}
+
+func TestSetDefaultVersion(t *testing.T) {
+	r := newMockRunner()
+	mgr := NewManager(r, newTestLogger(t))
+
+	err := mgr.SetDefaultVersion(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !r.called("wsl.exe", "--set-default-version", "2") {
+		t.Error("expected wsl.exe --set-default-version 2 call")
+	}
+}
+
+func TestStopCallsShutdown(t *testing.T) {
+	r := newMockRunner()
+	mgr := NewManager(r, newTestLogger(t))
+
+	err := mgr.Stop(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !r.called("wsl.exe", "--shutdown") {
+		t.Error("expected wsl.exe --shutdown call")
+	}
+}
+
+func TestIsDistroInstalledTrue(t *testing.T) {
+	r := newMockRunner()
+	r.outputs[r.key("wsl.exe", "--list", "--verbose")] =
+		"  NAME      STATE     VERSION\n* Ubuntu    Running   2\n  Debian    Stopped   2\n"
+
+	mgr := NewManager(r, newTestLogger(t))
+	installed, err := mgr.IsDistroInstalled(context.Background(), "Ubuntu")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !installed {
+		t.Error("expected true for Ubuntu")
+	}
+}
+
+func TestIsDistroInstalledFalse(t *testing.T) {
+	r := newMockRunner()
+	r.outputs[r.key("wsl.exe", "--list", "--verbose")] =
+		"  NAME      STATE     VERSION\n* Debian    Running   2\n"
+
+	mgr := NewManager(r, newTestLogger(t))
+	installed, err := mgr.IsDistroInstalled(context.Background(), "Ubuntu")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if installed {
+		t.Error("expected false for Ubuntu")
+	}
+}
+
+func TestIsDistroInstalledCaseInsensitive(t *testing.T) {
+	r := newMockRunner()
+	r.outputs[r.key("wsl.exe", "--list", "--verbose")] =
+		"  NAME      STATE     VERSION\n* ubuntu    Running   2\n"
+
+	mgr := NewManager(r, newTestLogger(t))
+	installed, err := mgr.IsDistroInstalled(context.Background(), "Ubuntu")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !installed {
+		t.Error("expected true (case insensitive)")
+	}
+}
+
+func TestInstallDistro(t *testing.T) {
+	r := newMockRunner()
+	mgr := NewManager(r, newTestLogger(t))
+
+	err := mgr.InstallDistro(context.Background(), "Ubuntu")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !r.called("wsl.exe", "--install", "-d", "Ubuntu") {
+		t.Error("expected wsl.exe --install -d Ubuntu call")
+	}
+	if !r.called("wsl.exe", "--setdefault", "Ubuntu") {
+		t.Error("expected wsl.exe --setdefault Ubuntu call")
+	}
+}
+
+func TestRemoveDistro(t *testing.T) {
+	r := newMockRunner()
+	mgr := NewManager(r, newTestLogger(t))
+
+	err := mgr.RemoveDistro(context.Background(), "Ubuntu")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !r.called("wsl.exe", "--unregister", "Ubuntu") {
+		t.Error("expected wsl.exe --unregister Ubuntu call")
+	}
+}
+
+func TestRunCommand(t *testing.T) {
+	r := newMockRunner()
+	r.outputs[r.key("wsl.exe", "-d", "Ubuntu", "--", "ls", "-la")] = "total 0\n"
+
+	mgr := NewManager(r, newTestLogger(t))
+	out, err := mgr.RunCommand(context.Background(), "Ubuntu", "ls", "-la")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "total 0\n" {
+		t.Errorf("output = %q, want %q", out, "total 0\n")
+	}
+}
+
+func TestContainsDistroWithDefaultMarker(t *testing.T) {
+	output := "  NAME      STATE     VERSION\n* Ubuntu    Running   2\n"
+	if !containsDistro(output, "Ubuntu") {
+		t.Error("should find Ubuntu with * marker")
+	}
+}
+
+func TestContainsDistroEmptyOutput(t *testing.T) {
+	if containsDistro("", "Ubuntu") {
+		t.Error("should not find Ubuntu in empty output")
+	}
+}
+
+func TestIsDistroInstalledWhenWslFails(t *testing.T) {
+	r := newMockRunner()
+	r.errors[r.key("wsl.exe", "--list", "--verbose")] = fmt.Errorf("wsl not installed")
+
+	mgr := NewManager(r, newTestLogger(t))
+	installed, err := mgr.IsDistroInstalled(context.Background(), "Ubuntu")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if installed {
+		t.Error("expected false when wsl fails")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `ow.exe` Windows CLI to replace the PowerShell scripts (`RUNME.ps1`,
`CommonLibrary.psm1`). Same side-by-side pattern as milestone 2: PowerShell
scripts are untouched, `ow.exe` is opt-in, validated on real Windows before
milestone 4 removes PowerShell.

**8 commits, 16 files, +1,985 lines across 3 internal packages and 4 CLI command groups.**

### Packages

| Package | Purpose |
|---------|---------|
| `internal/wsl` | WSL2 lifecycle: install, update, shutdown, distro management, command execution |
| `internal/netsh` | Port proxy CRUD, firewall rule management via netsh |
| `internal/winfeature` | Windows optional features (WSL, VirtualMachinePlatform) via powershell.exe |

### CLI commands

| Command | Replaces |
|---------|----------|
| `ow setup` (Windows) | `RUNME.ps1` (full setup sequence) |
| `ow wsl install/remove/stop` | `Install-WslIfNeeded`, `Install-WslDistributionInteractive`, `Stop-Wsl` |
| `ow proxy enable/remove/show` | `Enable-OpenWebUIPortProxyIfNeeded`, `Show-PortProxyRules` |
| `ow diagnose` (Windows) | Diagnostic functions from `CommonLibrary.psm1` |

### Side-by-side design

PowerShell scripts are not modified. `ow.exe` reads `ow.yaml` only. Port proxy
and firewall rules use the same naming convention (`OpenWebUI-{addr}-{port}`)
so both tools produce identical rules.

## Testing

- All 3 packages have mock-based unit tests (windows build tag)
- Integration tests gated behind `windows && integration` build tag
- Cross-platform builds verified: `GOOS=windows`, `GOOS=linux`, `GOOS=darwin`
- Mutation testing (macOS-runnable): config 92%, exec 80%
- Windows-tagged mutation testing deferred to Windows CI/validation

**Not yet tested:** end-to-end `ow.exe setup` on real Windows 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)